### PR TITLE
Support deployment over multiple nodes

### DIFF
--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -28,9 +28,13 @@ case $RELEASE_COMMAND in
     ;;
 esac
 
+# get the machine's main network interface (listed after the "dev" string)
+MACHINE_INTERFACE=$(ip -o route get to 8.8.8.8 | sed -En 's/.*dev ([a-zA-Z0-9]+).*/\1/p')
+# get the interface's associated IPv4 address
+MACHINE_ADDR=$(ip -f inet addr show $MACHINE_INTERFACE | sed -En 's/.*inet ([0-9\.]+).*/\1/p')
+
 # Set the release to work across nodes.
 # RELEASE_DISTRIBUTION must be "sname" (local), "name" (distributed) or "none".
 export RELEASE_DISTRIBUTION=name
-export RELEASE_NODE=<%= @release.name %>@127.0.0.1
-
+export RELEASE_NODE=<%= @release.name %>@$MACHINE_ADDR
 export RELEASE_COOKIE="default_secret"

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -26,3 +26,6 @@
 
 ## Tweak GC to run more often
 ##-env ERL_FULLSWEEP_AFTER 10
+
+## Set address range for inter-node connections (useful for port forwarding and firewall rules)
+##-kernel inet_dist_listen_min 9001 inet_dist_listen_max 9001


### PR DESCRIPTION
This PR adds support for deploying multiple cores in the same network, on different nodes.

This was done by changing the name to include the local ip address, instead of simply the loopback address.

This closes #51.