### PR TITLE
workflow_dispatch trigger event

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -23,6 +23,7 @@ on:
       - "*"
     branches-ignore:
       - "*"
+  workflow_dispatch:
 
 jobs:
   binary:
@@ -31,7 +32,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      
+
       - name: Install dependencies
         run: |
           mix local.rebar --force

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -23,6 +23,7 @@ on:
       - "*"
     branches-ignore:
       - "*"
+  workflow_dispatch:
 
 jobs:
   docker:


### PR DESCRIPTION
Following the PR for the Core, the workflow_dispatch option is added to allow manual runs of the binary and docker releases.