### PR TITLE
Add timeout-specific error and reduce timeout duration

### DIFF
--- a/lib/core/adapters/commands/worker.ex
+++ b/lib/core/adapters/commands/worker.ex
@@ -45,6 +45,6 @@ defmodule Core.Adapters.Commands.Worker do
       "sending command #{cmd} to #{inspect(worker_addr)} with payload #{inspect(payload)}"
     )
 
-    GenServer.call(worker_addr, command, 300_000)
+    GenServer.call(worker_addr, command, 30_000)
   end
 end

--- a/lib/core/adapters/requests/http/server.ex
+++ b/lib/core/adapters/requests/http/server.ex
@@ -60,6 +60,24 @@ defmodule Core.Adapters.Requests.Http.Server do
   @impl Plug.ErrorHandler
   def handle_errors(conn, %{
         kind: _kind,
+        reason: {:timeout, {GenServer, :call, [{:worker, _} | _]}},
+        stack: _stack
+      }) do
+    resp =
+      Jason.encode!(%{
+        "error" => "The invocation timed out"
+      })
+
+    send_resp(
+      conn,
+      conn.status,
+      resp
+    )
+  end
+
+  @impl Plug.ErrorHandler
+  def handle_errors(conn, %{
+        kind: _kind,
         reason: _reason,
         stack: _stack
       }) do

--- a/lib/core/adapters/requests/http/server.ex
+++ b/lib/core/adapters/requests/http/server.ex
@@ -37,6 +37,8 @@ defmodule Core.Adapters.Requests.Http.Server do
   plug(:match)
   plug(:dispatch)
 
+  ### Error handling
+
   @impl Plug.ErrorHandler
   def handle_errors(conn, %{
         kind: _kind,
@@ -92,6 +94,8 @@ defmodule Core.Adapters.Requests.Http.Server do
       resp
     )
   end
+
+  ### Request handling
 
   # Invoke request handler
   post "/invoke" do


### PR DESCRIPTION
This PR adds an error handler for invocation timeouts and reduces timeout duration from 300s to 30s.

This closes #54.