### PR TITLE
Update Dockerfile and error replies header

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -53,6 +53,4 @@ jobs:
         with:
           context: .
           push: true
-          build-args: |
-            APP_NAME=core
           tags: ghcr.io/funlessdev/fl-core:latest,ghcr.io/funlessdev/fl-core:${{ env.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,9 @@ FROM elixir:1.13.4-alpine AS builder
 
 # The following are build arguments used to change variable parts of the image.
 # The name of your application/release (required)
-ARG APP_NAME
 ARG MIX_ENV=prod
 
-ENV APP_NAME=${APP_NAME} MIX_ENV=${MIX_ENV}
+ENV MIX_ENV=${MIX_ENV}
 # RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/cargo PATH=/opt/cargo/bin:$PATH
 
 # By convention, /opt is typically used for applications
@@ -50,7 +49,6 @@ RUN mix release
 # From this line onwards, we're in a new image, which will be the image used in production
 FROM alpine:${ALPINE_VERSION}
 
-ARG APP_NAME
 ARG MIX_ENV=prod
 ARG PORT=4001
 
@@ -60,12 +58,11 @@ RUN apk update && \
     apk add --no-cache libstdc++ libgcc ncurses-libs
 
 ENV REPLACE_OS_VARS=true \
-    APP_NAME=${APP_NAME} \
     MIX_ENV=${MIX_ENV} \ 
     PORT=${PORT} 
 
 WORKDIR /opt/app
 
-COPY --from=builder /opt/app/_build/${MIX_ENV}/rel/${APP_NAME} .
+COPY --from=builder /opt/app/_build/${MIX_ENV}/rel/core .
 
-CMD PORT=${PORT} /opt/app/bin/${APP_NAME} start
+CMD PORT=${PORT} /opt/app/bin/core start

--- a/lib/core/adapters/requests/http/server.ex
+++ b/lib/core/adapters/requests/http/server.ex
@@ -52,6 +52,8 @@ defmodule Core.Adapters.Requests.Http.Server do
         "error" => "The provided body was not a valid JSON string"
       })
 
+    conn = put_resp_content_type(conn, "application/json", nil)
+
     send_resp(
       conn,
       conn.status,
@@ -70,6 +72,8 @@ defmodule Core.Adapters.Requests.Http.Server do
         "error" => "The invocation timed out"
       })
 
+    conn = put_resp_content_type(conn, "application/json", nil)
+
     send_resp(
       conn,
       conn.status,
@@ -87,6 +91,8 @@ defmodule Core.Adapters.Requests.Http.Server do
       Jason.encode!(%{
         "error" => "Something went wrong"
       })
+
+    conn = put_resp_content_type(conn, "application/json", nil)
 
     send_resp(
       conn,

--- a/lib/core/domain/api/invoker.ex
+++ b/lib/core/domain/api/invoker.ex
@@ -88,7 +88,7 @@ defmodule Core.Domain.Api.Invoker do
 
   defp parse_wrk_reply({:error, err}) do
     err_msg = err["error"] || "Unknown error"
-    Logger.error("API: received error reply from worker #{err_msg}")
+    Logger.error("API: received error reply from worker #{inspect(err_msg)}")
     {:error, :worker_error}
   end
 end


### PR DESCRIPTION
This PR adds the application/json header in case of error replies and remove the APP_NAME build-arg from the docker file as it is not really needed, plus some small fixes.