### PR TITLE
Openapi fixes

### DIFF
--- a/core-api.yaml
+++ b/core-api.yaml
@@ -22,7 +22,7 @@ info:
   version: "1.0"
 components:
   schemas:
-    invocation:
+    function_invocation:
       type: object
       properties:
         namespace:
@@ -31,6 +31,19 @@ components:
           type: string
         args:
           type: object
+    function_invocation_success:
+      type: object
+      properties:
+        result:
+          type: object
+          description: The function invocation result
+    function_invocation_error:
+      type: object
+      properties:
+        error:
+          type: string
+          description: The error message
+
     function_creation:
       type: object
       properties:
@@ -42,6 +55,19 @@ components:
           type: string
         image:
           type: string
+    function_creation_success:
+      type: object
+      properties:
+        result:
+          type: string
+          description: The name of the function
+    function_creation_error:
+      type: object
+      properties:
+        error:
+          type: string
+          description: The error message
+
     function_deletion:
       type: object
       properties:
@@ -49,6 +75,19 @@ components:
           type: string
         namespace:
           type: string
+    function_deletion_success:
+      type: object
+      properties:
+        result:
+          type: string
+          description: The name of the function
+    function_deletion_error:
+      type: object
+      properties:
+        error:
+          type: string
+          description: The error message
+
 paths:
   /invoke:
     post:
@@ -64,51 +103,36 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/invocation"
+              $ref: "#/components/schemas/function_invocation"
       responses:
         "200":
           description: The function invocation was successfully sent to a worker
           content:
             application/json:
               schema:
-                description: The function invocation result
-                type: object
-                properties:
-                  result:
-                    type: object
+                $ref: "#/components/schemas/function_invocation_success"
               examples:
                 Invocation of hello world:
-                  value: '{"result": "Hello, World!"}'
+                  value: '{"result": {"payload": "Hello, World!"}}'
         "400":
           description: The invocation request was invalid
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: The error message
+                $ref: "#/components/schemas/function_invocation_error"
+
         "404":
           description: The required function was not found
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: The error message
+                $ref: "#/components/schemas/function_invocation_error"
         "500":
           description: The function invocation failed for some unspecified internal error
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: The error message
+                $ref: "#/components/schemas/function_invocation_error"
               examples:
                 Invocation with internal error:
                   value: '{"error": "Failed to invoke function: internal worker error"}'
@@ -117,11 +141,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: The error message
+                $ref: "#/components/schemas/function_invocation_error"
               examples:
                 Invocation with no workers:
                   value: '{"error": "Failed to invoke function: no worker available"}'
@@ -144,11 +164,7 @@ paths:
           content:
             application/json:
               schema:
-                description: The name of the function
-                type: object
-                properties:
-                  result:
-                    type: object
+                $ref: "#/components/schemas/function_creation_success"
               examples:
                 Creation of the "hellojs" function:
                   value: '{"result": "hellojs"}'
@@ -157,21 +173,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: The error message
+                $ref: "#/components/schemas/function_creation_error"
         "500":
           description: The function creation request failed because the database transaction was aborted
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: The error message
+                $ref: "#/components/schemas/function_creation_error"
   /delete:
     post:
       summary: Delete a function
@@ -191,11 +199,7 @@ paths:
           content:
             application/json:
               schema:
-                description: The name of the function
-                type: object
-                properties:
-                  result:
-                    type: object
+                $ref: "#/components/schemas/function_deletion_success"
               examples:
                 Deletion of the "hellojs" function:
                   value: '{"result": "hellojs"}'
@@ -204,21 +208,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: The error message
+                $ref: "#/components/schemas/function_deletion_error"
         "500":
           description: The function deletion request failed because the database transaction was aborted
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: The error message
+                $ref: "#/components/schemas/function_deletion_error"
 
 servers:
   - url: http://localhost:4001

--- a/lib/core/adapters/requests/http/server.ex
+++ b/lib/core/adapters/requests/http/server.ex
@@ -107,7 +107,7 @@ defmodule Core.Adapters.Requests.Http.Server do
   post "/invoke" do
     res = Api.Invoker.invoke(conn.body_params)
     conn = put_resp_content_type(conn, "application/json", nil)
-    reply_to_client(res, conn)
+    reply_to_client_invoke(res, conn)
   end
 
   # Function creation request handler
@@ -128,6 +128,14 @@ defmodule Core.Adapters.Requests.Http.Server do
     body = Jason.encode!(%{"error" => "Oops, this endpoint is not implemented yet"})
     conn = put_resp_content_type(conn, "application/json", nil)
     send_resp(conn, 404, body)
+  end
+
+  defp reply_to_client_invoke({:ok, result}, conn) do
+    reply_to_client({:ok, %{"result" => result}}, conn)
+  end
+
+  defp reply_to_client_invoke(any, conn) do
+    reply_to_client(any, conn)
   end
 
   defp reply_to_client({:ok, result}, conn) do

--- a/lib/core/domain/api/invoker.ex
+++ b/lib/core/domain/api/invoker.ex
@@ -26,7 +26,7 @@ defmodule Core.Domain.Api.Invoker do
   alias Core.Domain.Ports.FunctionStorage
   alias Core.Domain.Scheduler
 
-  @spec invoke(Map.t()) :: {:ok, %{:result => String.t()}} | {:error, any}
+  @spec invoke(Map.t()) :: {:ok, any} | {:error, any}
   @doc """
   Sends an invocation request for the `name` function in the `ns` namespace,
   specified in the invocation parameters.

--- a/test/integration/http_server_tests/invoker_test.exs
+++ b/test/integration/http_server_tests/invoker_test.exs
@@ -86,7 +86,7 @@ defmodule HttpServerTest.InvokeTest do
 
       # Assert the response and status
       Common.assert_http_response(conn, 200, %{
-        "result" => "Hello, World!"
+        "result" => %{"result" => "Hello, World!"}
       })
     end
 


### PR DESCRIPTION
This PR adds a missing `%{"result"=>...}` wrapper in the server response, and refactors `core-api.yaml` to explicitly define response schemas.