### PR TITLE
Change log location and update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,12 @@ ENV REPLACE_OS_VARS=true \
     MIX_ENV=${MIX_ENV} \ 
     PORT=${PORT} 
 
-WORKDIR /opt/app
+WORKDIR /home/funless
+RUN adduser --disabled-password --home "$(pwd)" funless &&\
+    echo "funless ALL=(ALL:ALL) NOPASSWD: ALL" >>/etc/sudoers
 
-COPY --from=builder /opt/app/_build/${MIX_ENV}/rel/core .
+USER funless
 
-CMD PORT=${PORT} /opt/app/bin/core start
+COPY --chown=funless --from=builder /opt/app/_build/${MIX_ENV}/rel/core ./core
+
+CMD PORT=${PORT} core/bin/core start

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -28,5 +28,5 @@ config :logger,
 
 # configuration for the {LoggerFileBackend, :info_log} backend
 config :logger, :info_log,
-  path: "fl-core.log",
+  path: "/tmp/funless/fl-core.log",
   level: :info


### PR DESCRIPTION
This PR closes #64 

It updates the dockerfile and puts it in line with the worker one, and changes the location of logs to /tmp/funless/. The new location will be used from the cli to map that folder in host.