### PR TITLE
Telemetry

### DIFF
--- a/lib/core/adapters/telemetry/native/api.ex
+++ b/lib/core/adapters/telemetry/native/api.ex
@@ -16,23 +16,19 @@
 # under the License.
 #
 
-import Config
+defmodule Core.Adapters.Telemetry.Native.Api do
+  @moduledoc """
+  Adapter to request telemetry data about workers.
+  """
+  @behaviour Core.Domain.Ports.Telemetry.Api
 
-config :core, Core.Domain.Ports.Commands, adapter: Core.Adapters.Commands.Worker
-config :core, Core.Domain.Ports.Cluster, adapter: Core.Adapters.Cluster
-config :core, Core.Domain.Ports.FunctionStorage, adapter: Core.Adapters.FunctionStorage.Mnesia
-config :core, Core.Domain.Ports.Telemetry.Api, adapter: Core.Adapters.Telemetry.Native.Api
+  @impl true
+  def resources(worker) do
+    res = :ets.lookup(:telemetry_ets_server, worker) |> Enum.map(fn {_w, r} -> r end)
 
-config :logger, :console,
-  format: "\n##### $time $metadata[$level] $levelpad$message\n",
-  metadata: [:error_code, :file, :line]
-
-config :libcluster,
-  topologies: [
-    funless: [
-      # The selected clustering strategy. Required.
-      strategy: Cluster.Strategy.Gossip
-    ]
-  ]
-
-import_config "#{Mix.env()}.exs"
+    case res do
+      [r | _] -> {:ok, r}
+      [] -> {:error, :not_found}
+    end
+  end
+end

--- a/lib/core/adapters/telemetry/native/api.ex
+++ b/lib/core/adapters/telemetry/native/api.ex
@@ -24,7 +24,7 @@ defmodule Core.Adapters.Telemetry.Native.Api do
 
   @impl true
   def resources(worker) do
-    res = :ets.lookup(:telemetry_ets_server, worker) |> Enum.map(fn {_w, r} -> r end)
+    res = :ets.lookup(:worker_resources, worker) |> Enum.map(fn {_w, r} -> r end)
 
     case res do
       [r | _] -> {:ok, r}

--- a/lib/core/adapters/telemetry/native/collector.ex
+++ b/lib/core/adapters/telemetry/native/collector.ex
@@ -19,29 +19,35 @@ defmodule Core.Adapters.Telemetry.Native.Collector do
   @moduledoc """
     Implements GenServer behaviour.
     Watches the status of nodes in the cluster and retrieves telemetry information from workers.
-    The GenServer state is a map of (worker_node -> pid) couples, where the pid identifies the process pulling the node for telemetry information.
+    The GenServer state is just the name of the dynamic supervisor used for handling the various InformationRetriever processes.
   """
   use GenServer, restart: :permanent
   require Logger
 
-  def start_link(_args) do
-    GenServer.start_link(__MODULE__, %{})
+  def start_link(dynamic_supervisor) do
+    GenServer.start_link(__MODULE__, dynamic_supervisor)
   end
 
   @impl true
-  def init(_args) do
+  def init(dynamic_supervisor) do
     :net_kernel.monitor_nodes(true)
     Logger.info("Telemetry Collector: started")
-    {:ok, %{}}
+    {:ok, dynamic_supervisor}
   end
 
   @impl true
-  def terminate(_reason, state) do
+  def terminate(_reason, dynamic_supervisor) do
     :net_kernel.monitor_nodes(false)
 
-    state
-    |> Enum.each(fn {_w, pid} ->
-      Process.exit(pid, :parent)
+    Node.list()
+    |> Enum.each(fn node ->
+      pids =
+        Registry.lookup(Core.Adapters.Telemetry.Native.Registry, "telemetry_information_#{node}")
+
+      case pids do
+        [{pid, _} | _] -> DynamicSupervisor.terminate_child(dynamic_supervisor, pid)
+        _ -> nil
+      end
     end)
 
     Logger.info("Telemetry Collector: terminated")
@@ -49,55 +55,35 @@ defmodule Core.Adapters.Telemetry.Native.Collector do
   end
 
   @impl true
-  def handle_info({:nodeup, node}, state) do
+  def handle_info({:nodeup, node}, dynamic_supervisor) do
     is_worker = node |> Atom.to_string() |> String.contains?("worker")
 
     if is_worker do
-      # TODO: use a DynamicSupervisor to handle addition/removal/restart of child processes
-      pid = spawn(__MODULE__, :retrieve_information, [node])
-
-      send(pid, :pull)
-      Logger.info("Telemetry Collector: monitoring of node #{node} started")
-
-      new_state = state |> Map.put(node, pid)
-      {:noreply, new_state}
-    else
-      {:noreply, state}
+      {:ok, _} =
+        DynamicSupervisor.start_child(
+          dynamic_supervisor,
+          {Core.Adapters.Telemetry.Native.InformationRetriever, node}
+        )
     end
+
+    {:noreply, dynamic_supervisor}
   end
 
   @impl true
-  def handle_info({:nodedown, node}, state) do
-    {pid, new_state} = state |> Map.pop(node)
+  def handle_info({:nodedown, node}, dynamic_supervisor) do
+    pids =
+      Registry.lookup(Core.Adapters.Telemetry.Native.Registry, "telemetry_information_#{node}")
 
-    if is_pid(pid) do
-      GenServer.call(:telemetry_ets_server, {:delete, node})
-      Process.exit(pid, :disconnected)
-      Logger.info("Telemetry Collector: monitoring of node #{node} stopped")
+    case pids do
+      [{pid, _} | _] ->
+        GenServer.call(:telemetry_ets_server, {:delete, node})
+        DynamicSupervisor.terminate_child(dynamic_supervisor, pid)
+        Logger.info("Telemetry Collector: monitoring of node #{node} stopped")
+
+      _ ->
+        nil
     end
 
-    {:noreply, new_state}
-  end
-
-  @doc """
-    Pulls telemetry information from the given worker node every 5s.
-  """
-  def retrieve_information(worker) do
-    receive do
-      :pull ->
-        response = GenServer.call({:worker_telemetry, worker}, :pull)
-
-        case response do
-          {:ok, res} ->
-            resources = res |> Map.put(:timestamp, DateTime.utc_now())
-            GenServer.call(:telemetry_ets_server, {:insert, worker, resources})
-
-          {:error, _} ->
-            nil
-        end
-
-        Process.send_after(self(), :pull, 5_000)
-        retrieve_information(worker)
-    end
+    {:noreply, dynamic_supervisor}
   end
 end

--- a/lib/core/adapters/telemetry/native/collector.ex
+++ b/lib/core/adapters/telemetry/native/collector.ex
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+defmodule Core.Adapters.Telemetry.Native.Collector do
+  @moduledoc """
+    Implements GenServer behaviour.
+    Watches the status of nodes in the cluster and retrieves telemetry information from workers.
+    The GenServer state is a map of (worker_node -> pid) couples, where the pid identifies the process pulling the node for telemetry information.
+  """
+  use GenServer, restart: :permanent
+  require Logger
+
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, %{})
+  end
+
+  @impl true
+  def init(_args) do
+    :net_kernel.monitor_nodes(true)
+    Logger.info("Telemetry Collector: started")
+    {:ok, %{}}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    :net_kernel.monitor_nodes(false)
+
+    state
+    |> Enum.each(fn {_w, pid} ->
+      Process.exit(pid, :parent)
+    end)
+
+    Logger.info("Telemetry Collector: terminated")
+    :ok
+  end
+
+  @impl true
+  def handle_info({:nodeup, node}, state) do
+    is_worker = node |> Atom.to_string() |> String.contains?("worker")
+
+    if is_worker do
+      # TODO: use a DynamicSupervisor to handle addition/removal/restart of child processes
+      pid = spawn(__MODULE__, :retrieve_information, [node])
+
+      send(pid, :pull)
+      Logger.info("Telemetry Collector: monitoring of node #{node} started")
+
+      new_state = state |> Map.put(node, pid)
+      {:noreply, new_state}
+    else
+      {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_info({:nodedown, node}, state) do
+    {pid, new_state} = state |> Map.pop(node)
+
+    if is_pid(pid) do
+      GenServer.call(:telemetry_ets_server, {:delete, node})
+      Process.exit(pid, :disconnected)
+      Logger.info("Telemetry Collector: monitoring of node #{node} stopped")
+    end
+
+    {:noreply, new_state}
+  end
+
+  @doc """
+    Pulls telemetry information from the given worker node every 5s.
+  """
+  def retrieve_information(worker) do
+    receive do
+      :pull ->
+        resources = GenServer.call({:worker_telemetry, worker}, :pull)
+        resources = resources |> Map.put(:timestamp, DateTime.utc_now())
+        GenServer.call(:telemetry_ets_server, {:insert, worker, resources})
+        Process.send_after(self(), :pull, 5_000)
+        retrieve_information(worker)
+    end
+  end
+end

--- a/lib/core/adapters/telemetry/native/ets_server.ex
+++ b/lib/core/adapters/telemetry/native/ets_server.ex
@@ -31,7 +31,7 @@ defmodule Core.Adapters.Telemetry.Native.EtsServer do
 
   @impl true
   def init(_args) do
-    table = :ets.new(:functions_runtimes, [:set, :named_table, :protected])
+    table = :ets.new(:worker_resources, [:set, :named_table, :protected])
     Logger.info("Telemetry ETS Server: started")
     {:ok, table}
   end

--- a/lib/core/adapters/telemetry/native/ets_server.ex
+++ b/lib/core/adapters/telemetry/native/ets_server.ex
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+defmodule Core.Adapters.Telemetry.Native.EtsServer do
+  @moduledoc """
+    Implements GenServer behaviour; represents a process having exclusive writing rights on an underlying ETS table.
+
+    The {worker_node, resources} couples are inserted or deleted by using GenServer.call() on this process; the table name is currently hardcoded to
+    :worker_resources.
+  """
+  use GenServer, restart: :permanent
+  require Logger
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: :telemetry_ets_server)
+  end
+
+  @impl true
+  def init(_args) do
+    table = :ets.new(:functions_runtimes, [:set, :named_table, :protected])
+    Logger.info("Telemetry ETS Server: started")
+    {:ok, table}
+  end
+
+  @impl true
+  def handle_call({:insert, worker_node, resources}, _from, table) do
+    :ets.insert(table, {worker_node, resources})
+    Logger.info("Telemetry ETS Server: added #{worker_node}")
+    {:reply, {:ok, {worker_node, resources}}, table}
+  end
+
+  @impl true
+  def handle_call({:delete, worker_node}, _from, table) do
+    :ets.delete(table, worker_node)
+    Logger.info("Telemetry ETS Server: deleted #{worker_node}")
+    {:reply, {:ok, worker_node}, table}
+  end
+end

--- a/lib/core/adapters/telemetry/native/information_retriever.ex
+++ b/lib/core/adapters/telemetry/native/information_retriever.ex
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+defmodule Core.Adapters.Telemetry.Native.InformationRetriever do
+  @moduledoc """
+    Implements GenServer behaviour. Represents a process periodically pulling telemetry information from a single worker.
+    This is meant to be run under a supervisor.
+  """
+  use GenServer, restart: :permanent
+  require Logger
+
+  def start_link(node) do
+    GenServer.start_link(__MODULE__, node,
+      name:
+        {:via, Registry,
+         {Core.Adapters.Telemetry.Native.Registry, "telemetry_information_#{node}"}}
+    )
+  end
+
+  @impl true
+  def init(node) do
+    Logger.info("Telemetry Information Retriever: monitoring of node #{node} started")
+    send(self(), :pull)
+    {:ok, node}
+  end
+
+  @impl true
+  def handle_info(:pull, node) do
+    retrieve_information(node)
+    {:noreply, node}
+  end
+
+  @doc """
+    Pulls telemetry information from the given worker node every 5s.
+  """
+  def retrieve_information(worker) do
+    if :rpc.call(worker, Process, :whereis, [:worker_telemetry]) != nil do
+      response = GenServer.call({:worker_telemetry, worker}, :pull)
+
+      case response do
+        {:ok, res} ->
+          resources = res |> Map.put(:timestamp, DateTime.utc_now())
+          GenServer.call(:telemetry_ets_server, {:insert, worker, resources})
+
+        {:error, _} ->
+          nil
+      end
+    else
+      Logger.warn(
+        "Telemetry Information Retriever: no worker_telemetry process found for #{worker}"
+      )
+    end
+
+    Process.send_after(self(), :pull, 5_000)
+  end
+end

--- a/lib/core/adapters/telemetry/native/supervisor.ex
+++ b/lib/core/adapters/telemetry/native/supervisor.ex
@@ -33,9 +33,15 @@ defmodule Core.Adapters.Telemetry.Native.Supervisor do
 
     children = [
       {Core.Adapters.Telemetry.Native.EtsServer, []},
-      {Core.Adapters.Telemetry.Native.Collector, []}
+      {DynamicSupervisor,
+       strategy: :one_for_one,
+       max_restarts: 5,
+       max_seconds: 5,
+       name: Core.Adapters.Telemetry.Native.DynamicSupervisor},
+      {Registry, keys: :unique, name: Core.Adapters.Telemetry.Native.Registry},
+      {Core.Adapters.Telemetry.Native.Collector, Core.Adapters.Telemetry.Native.DynamicSupervisor}
     ]
 
-    Supervisor.init(children, strategy: :rest_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/lib/core/adapters/telemetry/native/supervisor.ex
+++ b/lib/core/adapters/telemetry/native/supervisor.ex
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+defmodule Core.Adapters.Telemetry.Native.Supervisor do
+  @moduledoc """
+    Implements Supervisor behaviour; starts both the collector and the ETS server for handling worker telemetry information.
+  """
+  use Supervisor
+  require Logger
+
+  def start_link(args) do
+    Supervisor.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_args) do
+    Logger.info("Telemetry Supervisor: started")
+
+    children = [
+      {Core.Adapters.Telemetry.Native.EtsServer, []},
+      {Core.Adapters.Telemetry.Native.Collector, []}
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+end

--- a/lib/core/application.ex
+++ b/lib/core/application.ex
@@ -34,7 +34,8 @@ defmodule Core.Application do
 
     children = [
       {Cluster.Supervisor, [topologies, [name: Core.ClusterSupervisor]]},
-      {Bandit, plug: Core.Adapters.Requests.Http.Server, scheme: :http, options: [port: port]}
+      {Bandit, plug: Core.Adapters.Requests.Http.Server, scheme: :http, options: [port: port]},
+      {Core.Adapters.Telemetry.Native.Supervisor, []}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/core/domain/ports/telemetry/api.ex
+++ b/lib/core/domain/ports/telemetry/api.ex
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+defmodule Core.Domain.Ports.Telemetry.Api do
+  @moduledoc """
+  Port for requesting telemetry information about workers.
+  """
+  @type worker :: atom()
+  @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
+
+  @callback resources(worker) :: {:ok, any} | {:error, :not_found}
+
+  @doc """
+  Function to obtain resource information on a specific worker.
+  """
+  defdelegate resources(worker), to: @adapter
+end


### PR DESCRIPTION
This PR follows the changes proposed in https://github.com/funlessdev/fl-worker/pull/66.

It adds support for pulling telemetry data from various workers, following their addition to the cluster.
Similarly to the worker PR, it adds a dedicated Supervisor for the new processes, and an ETS server to store the worker data.