### PR TITLE
Action to genenerate and push openapi sdk

### DIFF
--- a/.github/workflows/generate-sdk.yml
+++ b/.github/workflows/generate-sdk.yml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: Core CI
+
+on:
+  push:
+    paths:
+    - 'core-api.yaml'
+  workflow_dispatch:
+
+jobs:
+  sdk-gen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: OpenAPI Generator Action
+        uses: kpurdon/openapi-generator-action@v0.0.3
+        with:
+          args: "generate -i core-api.yaml -g go -o ./generated-sdk"
+      - name: Pushes to fl-client-sdk-go
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: generated-sdk/
+          destination-github-username: 'funlessdev'
+          destination-repository-name: 'fl-client-sdk-go'
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY


### PR DESCRIPTION
This PR closes #63 

When core-api.yml changes the new generate-sdk action is triggered. it uses an action launch the open-api cli and generate the go sdk. Then with another action it pushes the files in the [fl-client-sdk-go](https://github.com/funlessdev/fl-client-sdk-go) repo. It uses ssh keys with the secret key added to this repo, with write access. And the public key in the client sdk repo. 