### PR TITLE
Types and deprecation warning

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,7 @@ config :core, Core.Domain.Ports.FunctionStorage, adapter: Core.Adapters.Function
 config :core, Core.Domain.Ports.Telemetry.Api, adapter: Core.Adapters.Telemetry.Native.Api
 
 config :logger, :console,
-  format: "\n##### $time $metadata[$level] $levelpad$message\n",
+  format: "\n##### $time $metadata[$level] $message\n",
   metadata: [:error_code, :file, :line]
 
 config :libcluster,

--- a/lib/core/adapters/cluster/cluster.ex
+++ b/lib/core/adapters/cluster/cluster.ex
@@ -23,5 +23,6 @@ defmodule Core.Adapters.Cluster do
   @behaviour Core.Domain.Ports.Cluster
 
   @impl true
+  @spec all_nodes :: [atom]
   def all_nodes, do: Node.list()
 end

--- a/lib/core/adapters/commands/worker.ex
+++ b/lib/core/adapters/commands/worker.ex
@@ -26,6 +26,8 @@ defmodule Core.Adapters.Commands.Worker do
   @behaviour Core.Domain.Ports.Commands
 
   @impl true
+  @spec send_invocation_command(atom(), FunctionStruct.t(), map()) ::
+          {:ok, %{:result => String.t()}} | {:error, atom}
   def send_invocation_command(worker, %FunctionStruct{} = function, args) do
     worker_addr = worker_address(worker)
     cmd = invoke_command(function, args)
@@ -34,8 +36,10 @@ defmodule Core.Adapters.Commands.Worker do
   end
 
   @doc false
+  @spec worker_address(atom()) :: {:worker, atom()}
   def worker_address(worker), do: {:worker, worker}
 
+  @spec invoke_command(FunctionStruct.t(), map()) :: {:invoke, FunctionStruct.t(), map()}
   def invoke_command(%FunctionStruct{} = function, args) do
     {:invoke, function, args}
   end

--- a/lib/core/adapters/function_storage/mnesia.ex
+++ b/lib/core/adapters/function_storage/mnesia.ex
@@ -24,6 +24,7 @@ defmodule Core.Adapters.FunctionStorage.Mnesia do
   @behaviour Core.Domain.Ports.FunctionStorage
 
   @impl true
+  @spec init_database(list(atom())) :: :ok | {:error, any}
   def init_database(nodes) do
     :mnesia.create_schema(nodes)
     |> create_table(nodes)
@@ -54,6 +55,7 @@ defmodule Core.Adapters.FunctionStorage.Mnesia do
   end
 
   @impl true
+  @spec get_function(String.t(), String.t()) :: {:ok, FunctionStruct.t()} | {:error, any}
   def get_function(function_name, function_namespace) do
     case :mnesia.dirty_read(Function, {function_name, function_namespace}) do
       [] -> {:error, :not_found}
@@ -62,6 +64,7 @@ defmodule Core.Adapters.FunctionStorage.Mnesia do
   end
 
   @impl true
+  @spec insert_function(FunctionStruct.t()) :: {:ok, String.t()} | {:error, any}
   def insert_function(%FunctionStruct{name: name, namespace: namespace} = function) do
     data = fn ->
       :mnesia.write({Function, {name, namespace}, Map.from_struct(function)})
@@ -74,6 +77,7 @@ defmodule Core.Adapters.FunctionStorage.Mnesia do
   end
 
   @impl true
+  @spec delete_function(String.t(), String.t()) :: {:ok, String.t()} | {:error, any}
   def delete_function(function_name, function_namespace) do
     data = fn ->
       :mnesia.delete({Function, {function_name, function_namespace}})

--- a/lib/core/adapters/telemetry/native/api.ex
+++ b/lib/core/adapters/telemetry/native/api.ex
@@ -22,7 +22,14 @@ defmodule Core.Adapters.Telemetry.Native.Api do
   """
   @behaviour Core.Domain.Ports.Telemetry.Api
 
+  @type metrics :: %{
+          cpu: number(),
+          load_avg: %{l1: number(), l5: number(), l15: number()},
+          memory: %{free: number(), available: number(), total: number()}
+        }
+
   @impl true
+  @spec resources(any) :: {:ok, metrics} | {:error, :not_found}
   def resources(worker) do
     res = :ets.lookup(:worker_resources, worker) |> Enum.map(fn {_w, r} -> r end)
 

--- a/lib/core/domain/ports/cluster.ex
+++ b/lib/core/domain/ports/cluster.ex
@@ -22,11 +22,12 @@ defmodule Core.Domain.Ports.Cluster do
 
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
-  @callback all_nodes() :: list()
+  @callback all_nodes() :: list(atom())
 
   @doc """
   Function to obtain a list with all active nodes in the cluster,
   which can be processed to retrieve all worker nodes.
   """
+  @spec all_nodes :: list(atom())
   defdelegate all_nodes, to: @adapter
 end

--- a/lib/core/domain/ports/commands.ex
+++ b/lib/core/domain/ports/commands.ex
@@ -19,11 +19,13 @@ defmodule Core.Domain.Ports.Commands do
   @moduledoc """
   Port for sending commands to workers.
   """
+
   @type worker :: atom()
+  @type fl_function :: Core.Domain.FunctionStruct.t()
 
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
-  @callback send_invocation_command(worker, Core.Domain.FunctionStruct.t(), map()) ::
+  @callback send_invocation_command(worker, fl_function, map()) ::
               {:ok, %{:result => String.t()}} | {:error, atom}
 
   @doc """
@@ -31,5 +33,7 @@ defmodule Core.Domain.Ports.Commands do
   It requires a worker (a fully qualified name of another node with the :worker actor on), a function struct and
   (optionally empty) function arguments.
   """
+  @spec send_invocation_command(worker, fl_function, map()) ::
+          {:ok, %{:result => String.t()}} | {:error, atom}
   defdelegate send_invocation_command(worker, function, args), to: @adapter
 end

--- a/lib/core/domain/ports/function_storage.ex
+++ b/lib/core/domain/ports/function_storage.ex
@@ -21,17 +21,15 @@ defmodule Core.Domain.Ports.FunctionStorage do
   """
   alias Core.Domain.FunctionStruct
 
-  @type function_name :: String.t()
-  @type function_namespace :: String.t()
+  @type f_name :: String.t()
+  @type f_namespace :: String.t()
 
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
-  @callback init_database([atom()]) :: :ok | {:error, any}
-  @callback get_function(function_name, function_namespace) ::
-              {:ok, FunctionStruct.t()} | {:error, any}
-  @callback insert_function(FunctionStruct.t()) :: {:ok, function_name} | {:error, any}
-  @callback delete_function(function_name, function_namespace) ::
-              {:ok, function_name} | {:error, any}
+  @callback init_database(list(atom())) :: :ok | {:error, any}
+  @callback get_function(f_name, f_namespace) :: {:ok, FunctionStruct.t()} | {:error, any}
+  @callback insert_function(FunctionStruct.t()) :: {:ok, f_name} | {:error, any}
+  @callback delete_function(f_name, f_namespace) :: {:ok, f_name} | {:error, any}
 
   @doc """
   Creates the Function database.
@@ -40,6 +38,7 @@ defmodule Core.Domain.Ports.FunctionStorage do
   ## Parameters
     - nodes: list of nodes where the database will be created
   """
+  @spec init_database(list(atom())) :: :ok | {:error, any}
   defdelegate init_database(nodes), to: @adapter
 
   @doc """
@@ -51,6 +50,7 @@ defmodule Core.Domain.Ports.FunctionStorage do
     - function_namespace: Namespace the function is in
 
   """
+  @spec get_function(f_name, f_namespace) :: {:ok, FunctionStruct.t()} | {:error, any}
   defdelegate get_function(function_name, function_namespace), to: @adapter
 
   @doc """
@@ -61,6 +61,7 @@ defmodule Core.Domain.Ports.FunctionStorage do
     - function: a FunctionStruct
 
   """
+  @spec insert_function(FunctionStruct.t()) :: {:ok, f_name} | {:error, any}
   defdelegate insert_function(function), to: @adapter
 
   @doc """
@@ -71,5 +72,6 @@ defmodule Core.Domain.Ports.FunctionStorage do
     - function_name: Name of the function, unique in a namespace
     - function_namespace: Namespace the function is in
   """
+  @spec delete_function(f_name, f_namespace) :: {:ok, f_name} | {:error, any}
   defdelegate delete_function(function_name, function_namespace), to: @adapter
 end

--- a/lib/core/domain/ports/telemetry/api.ex
+++ b/lib/core/domain/ports/telemetry/api.ex
@@ -20,10 +20,16 @@ defmodule Core.Domain.Ports.Telemetry.Api do
   @moduledoc """
   Port for requesting telemetry information about workers.
   """
+  @type metrics :: %{
+          cpu: number(),
+          load_avg: %{l1: number(), l5: number(), l15: number()},
+          memory: %{free: number(), available: number(), total: number()}
+        }
+
   @type worker :: atom()
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
-  @callback resources(worker) :: {:ok, any} | {:error, :not_found}
+  @callback resources(worker) :: {:ok, metrics} | {:error, :not_found}
 
   @doc """
   Function to obtain resource information on a specific worker.


### PR DESCRIPTION
This PR adds more type specs which is useful for documentation and Dyalizer.
It also removes $levelpad from log config cause it is being deprecated.