### PR TITLE
fn/create in phoenix json api

### DIFF
--- a/apps/core/lib/core/domain/api/function_repo.ex
+++ b/apps/core/lib/core/domain/api/function_repo.ex
@@ -29,18 +29,18 @@ defmodule Core.Domain.Api.FunctionRepo do
   - `function`: FunctionStruct to be stored.
 
   ## Returns
-  - `{:ok, %{"result" => function_name}}`: if the function was successfully stored.
+  - `{:ok, %{result: function_name}}`: if the function was successfully stored.
   - `{:error, :bad_params}`: if the function is not a valid FunctionStruct.
   - `{:error, {:aborted, reason}}`: if the function could not be stored.
   """
   @spec new(FunctionStruct.t()) ::
           {:ok, ResultStruct.t()} | {:error, :bad_params} | {:error, {:bad_insert, any}}
-  def new(%{"name" => name, "code" => code, "image" => image} = raw_params) do
+  def new(%{"name" => name, "code" => code} = raw_params) do
     function = %FunctionStruct{
       name: name,
       namespace: raw_params["namespace"] || "_",
-      image: image,
-      code: code
+      code: code,
+      image: raw_params["image"] || "_"
     }
 
     Logger.info("API: create request for function #{name} in namespace #{function.namespace}")

--- a/apps/core/lib/core/domain/api/function_repo.ex
+++ b/apps/core/lib/core/domain/api/function_repo.ex
@@ -20,7 +20,6 @@ defmodule Core.Domain.Api.FunctionRepo do
   require Logger
   alias Core.Domain.FunctionStruct
   alias Core.Domain.Ports.FunctionStorage
-  alias Core.Domain.ResultStruct
 
   @doc """
   Stores a new function in the FunctionStorage.
@@ -34,7 +33,7 @@ defmodule Core.Domain.Api.FunctionRepo do
   - `{:error, {:aborted, reason}}`: if the function could not be stored.
   """
   @spec new(FunctionStruct.t()) ::
-          {:ok, ResultStruct.t()} | {:error, :bad_params} | {:error, {:bad_insert, any}}
+          {:ok, String.t()} | {:error, :bad_params} | {:error, {:bad_insert, any}}
   def new(%{"name" => name, "code" => code} = raw_params) do
     function = %FunctionStruct{
       name: name,
@@ -45,15 +44,9 @@ defmodule Core.Domain.Api.FunctionRepo do
 
     Logger.info("API: create request for function #{name} in namespace #{function.namespace}")
 
-    FunctionStorage.insert_function(function)
-    |> case do
-      {:ok, function_name} ->
-        {:ok, %ResultStruct{result: function_name}}
-
-      {:error, {:aborted, reason}} ->
-        Logger.error("API: create request for function #{name} failed: #{inspect(reason)}")
-        {:error, {:bad_insert, reason}}
-    end
+    function
+    |> FunctionStorage.insert_function()
+    |> parse_create_result(name)
   end
 
   def new(_), do: {:error, :bad_params}
@@ -69,20 +62,37 @@ defmodule Core.Domain.Api.FunctionRepo do
   - `{:error, :bad_params}`: if the function is not a valid FunctionStruct.
   - `{:error, {:bad_delete, reason}}`: if the function could not be deleted.
   """
-  @spec delete(FunctionStruct.t()) :: {:ok, ResultStruct.t()} | {:error, {:bad_delete, any}}
+  @spec delete(FunctionStruct.t()) :: {:ok, String.t()} | {:error, {:bad_delete, any}}
   def delete(%{"name" => name, "namespace" => namespace}) do
     Logger.info("API: delete request for function #{name} in namespace #{namespace}")
-    res = FunctionStorage.delete_function(name, namespace)
 
-    case res do
-      {:ok, function_name} ->
-        {:ok, %ResultStruct{result: function_name}}
-
-      {:error, {:aborted, reason}} ->
-        Logger.error("API: delete request for function #{name} failed: #{inspect(reason)}")
-        {:error, {:bad_delete, reason}}
-    end
+    FunctionStorage.delete_function(name, namespace)
+    |> parse_delete_result(name)
   end
 
   def delete(_), do: {:error, :bad_params}
+
+  @spec parse_create_result({:ok, String.t()} | {:error, {:aborted, any}}, String.t()) ::
+          {:ok, String.t()} | {:error, {:bad_insert, any}}
+  defp parse_create_result({:error, {:aborted, reason}}, f_name) do
+    Logger.error("API: create request for function #{f_name} failed: #{inspect(reason)}")
+    {:error, {:bad_insert, reason}}
+  end
+
+  defp parse_create_result(result, f_name) do
+    Logger.info("API: function #{f_name} stored successfully")
+    result
+  end
+
+  @spec parse_delete_result({:ok, String.t()} | {:error, {:aborted, any}}, String.t()) ::
+          {:ok, String.t()} | {:error, {:bad_delete, any}}
+  def parse_delete_result({:error, {:aborted, reason}}, f_name) do
+    Logger.error("API: delete request for function #{f_name} failed: #{inspect(reason)}")
+    {:error, {:bad_delete, reason}}
+  end
+
+  def parse_delete_result(result, f_name) do
+    Logger.info("API: function #{f_name} deleted successfully")
+    result
+  end
 end

--- a/apps/core/lib/core/domain/ports/function_storage.ex
+++ b/apps/core/lib/core/domain/ports/function_storage.ex
@@ -18,15 +18,14 @@ defmodule Core.Domain.Ports.FunctionStorage do
   """
   alias Core.Domain.FunctionStruct
 
-  @type f_name :: String.t()
-  @type f_namespace :: String.t()
-
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
   @callback init_database(list(atom())) :: :ok | {:error, any}
-  @callback get_function(f_name, f_namespace) :: {:ok, FunctionStruct.t()} | {:error, :not_found}
-  @callback insert_function(FunctionStruct.t()) :: {:ok, f_name} | {:error, {:aborted, any}}
-  @callback delete_function(f_name, f_namespace) :: {:ok, f_name} | {:error, {:aborted, any}}
+  @callback get_function(String.t(), String.t()) ::
+              {:ok, FunctionStruct.t()} | {:error, :not_found}
+  @callback insert_function(FunctionStruct.t()) :: {:ok, String.t()} | {:error, {:aborted, any}}
+  @callback delete_function(String.t(), String.t()) ::
+              {:ok, String.t()} | {:error, {:aborted, any}}
 
   @doc """
   Creates the Function database.
@@ -46,8 +45,11 @@ defmodule Core.Domain.Ports.FunctionStorage do
     - function_name: Name of the function, unique in a namespace
     - function_namespace: Namespace the function is in
 
+  ## Returns
+    - {:ok, function}: if the function was found
+    - {:error, :not_found}: if the function was not found
   """
-  @spec get_function(f_name, f_namespace) :: {:ok, FunctionStruct.t()} | {:error, :not_found}
+  @spec get_function(String.t(), String.t()) :: {:ok, FunctionStruct.t()} | {:error, :not_found}
   defdelegate get_function(function_name, function_namespace), to: @adapter
 
   @doc """
@@ -61,7 +63,7 @@ defmodule Core.Domain.Ports.FunctionStorage do
     - {:ok, function_name}: if the function was successfully stored.
     - {:error, {:aborted, reason}}: if the function could not be stored.
   """
-  @spec insert_function(FunctionStruct.t()) :: {:ok, f_name} | {:error, {:aborted, any}}
+  @spec insert_function(FunctionStruct.t()) :: {:ok, String.t()} | {:error, {:aborted, any}}
   defdelegate insert_function(function), to: @adapter
 
   @doc """
@@ -71,7 +73,11 @@ defmodule Core.Domain.Ports.FunctionStorage do
   ## Parameters
     - function_name: Name of the function, unique in a namespace
     - function_namespace: Namespace the function is in
+
+  ## Returns
+    - {:ok, function_name}: if the function was successfully deleted.
+    - {:error, {:aborted, reason}}: if the function could not be deleted.
   """
-  @spec delete_function(f_name, f_namespace) :: {:ok, f_name} | {:error, {:aborted, any}}
+  @spec delete_function(String.t(), String.t()) :: {:ok, String.t()} | {:error, {:aborted, any}}
   defdelegate delete_function(function_name, function_namespace), to: @adapter
 end

--- a/apps/core/lib/core/domain/structs.ex
+++ b/apps/core/lib/core/domain/structs.ex
@@ -28,7 +28,7 @@ defmodule Core.Domain.FunctionStruct do
           code: String.t(),
           image: String.t()
         }
-  @enforce_keys [:name, :namespace, :code, :image]
+  @enforce_keys [:name, :namespace, :code]
   defstruct [:name, :namespace, :code, :image]
 end
 

--- a/apps/core/test/integration/http_server_tests/storage_test.exs
+++ b/apps/core/test/integration/http_server_tests/storage_test.exs
@@ -33,22 +33,6 @@ defmodule HttpServerTest.FunctionStorageTest do
       :ok
     end
 
-    test "/create should return 200 when the creation is successful" do
-      conn =
-        conn(:post, "/create", %{
-          "name" => "hello",
-          "namespace" => "ns",
-          "code" => "some code",
-          "image" => "nodejs"
-        })
-
-      # Invoke the plug
-      conn = Server.call(conn, @opts)
-
-      # Assert the response and status
-      Common.assert_http_response(conn, 200, %{"result" => "hello"})
-    end
-
     test "/create should return 400 when given bad parameters" do
       conn =
         conn(:post, "/create", %{
@@ -99,7 +83,7 @@ defmodule HttpServerTest.FunctionStorageTest do
       conn = Server.call(conn, @opts)
 
       # Assert the response and status
-      Common.assert_http_response(conn, 200, %{"result" => "hello"})
+      Common.assert_http_response(conn, 200, "hello")
     end
 
     test "/delete should return 400 when given bad parameters" do

--- a/apps/core/test/unit/api_test/function_test.exs
+++ b/apps/core/test/unit/api_test/function_test.exs
@@ -35,19 +35,18 @@ defmodule ApiTest.FunctionTest do
       f = %{
         "name" => "hello",
         "namespace" => "ns",
-        "code" => "console.log(\"hello\")",
-        "image" => "nodejs"
+        "code" => "console.log(\"hello\")"
       }
 
-      assert Api.FunctionRepo.new(f) == {:ok, %ResultStruct{result: "hello"}}
+      assert Api.FunctionRepo.new(f) == {:ok, "hello"}
     end
 
     test "new_function should return {:error, :bad_params} when the given parameter map lacks the necessary keys" do
-      f = %{"name" => "hello", "code" => "some code"}
+      f = %{"name" => "hello"}
       assert Api.FunctionRepo.new(f) == {:error, :bad_params}
     end
 
-    test "new_function should return {:ok, %{result: function_name}} and ignore unused parameters in the input map when unnecessary keys are given" do
+    test "new_function should return {:ok, function_name} and ignore unused parameters in the input map when unnecessary keys are given" do
       f = %{
         "name" => "hello",
         "code" => "some code",
@@ -67,12 +66,12 @@ defmodule ApiTest.FunctionTest do
       end)
       |> Mox.expect(:insert_function, 0, fn _ -> {:error, "some error"} end)
 
-      assert Api.FunctionRepo.new(f) == {:ok, %ResultStruct{result: "hello"}}
+      assert Api.FunctionRepo.new(f) == {:ok, "hello"}
     end
 
     test "delete_function should return {:ok, %{result => function_name}} when no error occurs" do
       assert Api.FunctionRepo.delete(%{"name" => "hello", "namespace" => "ns"}) ==
-               {:ok, %ResultStruct{result: "hello"}}
+               {:ok, "hello"}
     end
 
     test "delete_function should return {:error, :bad_params}  when the given parameter map lacks the necessary keys" do

--- a/apps/core_web/lib/core_web/controllers/fn_controller.ex
+++ b/apps/core_web/lib/core_web/controllers/fn_controller.ex
@@ -20,8 +20,8 @@ defmodule CoreWeb.FnController do
   action_fallback(CoreWeb.FnFallbackController)
 
   def create(conn, params) do
-    with {:ok, result} <- FunctionRepo.new(params) do
-      render(conn, "create.json", result)
+    with {:ok, function_name} <- FunctionRepo.new(params) do
+      render(conn, "create.json", function_name: function_name)
     end
   end
 end

--- a/apps/core_web/lib/core_web/controllers/fn_controller.ex
+++ b/apps/core_web/lib/core_web/controllers/fn_controller.ex
@@ -1,0 +1,30 @@
+defmodule CoreWeb.FnController do
+  use CoreWeb, :controller
+
+  alias Core.Domain.Api.FunctionRepo
+
+  action_fallback(CoreWeb.FnFallbackController)
+
+  def create(conn, params) do
+    with {:ok, result} <- FunctionRepo.new(params) do
+      render(conn, "create.json", result)
+    end
+  end
+end
+
+defmodule CoreWeb.FnFallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+
+  use Phoenix.Controller
+
+  def call(conn, {:error, :bad_params}) do
+    conn
+    |> put_status(:bad_request)
+    |> put_view(CoreWeb.ErrorView)
+    |> render("bad_create_request.json")
+  end
+end

--- a/apps/core_web/lib/core_web/controllers/fn_controller.ex
+++ b/apps/core_web/lib/core_web/controllers/fn_controller.ex
@@ -1,3 +1,17 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 defmodule CoreWeb.FnController do
   use CoreWeb, :controller
 
@@ -25,6 +39,13 @@ defmodule CoreWeb.FnFallbackController do
     conn
     |> put_status(:bad_request)
     |> put_view(CoreWeb.ErrorView)
-    |> render("bad_create_request.json")
+    |> render("create_bad_request.json")
+  end
+
+  def call(conn, {:error, {:bad_insert, reason}}) do
+    conn
+    |> put_status(:service_unavailable)
+    |> put_view(CoreWeb.ErrorView)
+    |> render("create_db_aborted.json", reason: reason)
   end
 end

--- a/apps/core_web/lib/core_web/router.ex
+++ b/apps/core_web/lib/core_web/router.ex
@@ -19,8 +19,12 @@ defmodule CoreWeb.Router do
     plug(:accepts, ["json"])
   end
 
-  scope "/api", CoreWeb do
+  scope "/v1", CoreWeb do
     pipe_through(:api)
+
+    scope "/fn" do
+      post("/create", FnController, :create)
+    end
   end
 
   # Enables LiveDashboard only for development

--- a/apps/core_web/lib/core_web/views/error_view.ex
+++ b/apps/core_web/lib/core_web/views/error_view.ex
@@ -28,7 +28,15 @@ defmodule CoreWeb.ErrorView do
     %{errors: %{detail: Phoenix.Controller.status_message_from_template(template)}}
   end
 
-  def render("bad_create_request.json", _assigns) do
+  def render("create_bad_request.json", _assigns) do
     %{errors: %{detail: "Failed to create new function: bad request"}}
+  end
+
+  def render("create_db_aborted.json", %{reason: reason}) do
+    %{
+      errors: %{
+        detail: "Failed to create new function: database error because #{reason}"
+      }
+    }
   end
 end

--- a/apps/core_web/lib/core_web/views/error_view.ex
+++ b/apps/core_web/lib/core_web/views/error_view.ex
@@ -27,4 +27,8 @@ defmodule CoreWeb.ErrorView do
   def template_not_found(template, _assigns) do
     %{errors: %{detail: Phoenix.Controller.status_message_from_template(template)}}
   end
+
+  def render("bad_create_request.json", _assigns) do
+    %{errors: %{detail: "Failed to create new function: bad request"}}
+  end
 end

--- a/apps/core_web/lib/core_web/views/fn_view.ex
+++ b/apps/core_web/lib/core_web/views/fn_view.ex
@@ -1,0 +1,21 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule CoreWeb.FnView do
+  use CoreWeb, :view
+
+  def render("create.json", %{function_name: name}) do
+    %{result: name}
+  end
+end

--- a/apps/core_web/test/core_web/controllers/fn_controller_test.exs
+++ b/apps/core_web/test/core_web/controllers/fn_controller_test.exs
@@ -12,26 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule CoreWeb.ErrorViewTest do
+defmodule CoreWeb.FnControllerTest do
   use CoreWeb.ConnCase, async: true
 
-  # Bring render/3 and render_to_string/3 for testing custom views
-  import Phoenix.View
+  describe "POST /v1/fn/create" do
+    test "error: does not create, returns 400 when given invalid params", %{conn: conn} do
+      conn = post(conn, "/v1/fn/create", %{bad: "params"})
 
-  test "renders 404.json" do
-    assert render(CoreWeb.ErrorView, "404.json", []) == %{errors: %{detail: "Not Found"}}
-  end
+      assert body = json_response(conn, 400)
 
-  test "renders 500.json" do
-    assert render(CoreWeb.ErrorView, "500.json", []) ==
-             %{errors: %{detail: "Internal Server Error"}}
-  end
+      actual_errors = body["errors"]
+      refute Enum.empty?(actual_errors)
 
-  test "renders bad_create_request.json" do
-    out = %{
-      errors: %{detail: "Failed to create new function: bad request"}
-    }
+      expected_error_keys = ["detail"]
 
-    assert render(CoreWeb.ErrorView, "bad_create_request.json", []) == out
+      assert expected_error_keys == Map.keys(actual_errors)
+    end
   end
 end

--- a/apps/core_web/test/core_web/views/error_view_test.exs
+++ b/apps/core_web/test/core_web/views/error_view_test.exs
@@ -27,11 +27,21 @@ defmodule CoreWeb.ErrorViewTest do
              %{errors: %{detail: "Internal Server Error"}}
   end
 
-  test "renders bad_create_request.json" do
+  test "renders create_bad_request.json" do
     out = %{
       errors: %{detail: "Failed to create new function: bad request"}
     }
 
-    assert render(CoreWeb.ErrorView, "bad_create_request.json", []) == out
+    assert render(CoreWeb.ErrorView, "create_bad_request.json", []) == out
+  end
+
+  test "renders create_db_aborted.json" do
+    out = %{
+      errors: %{
+        detail: "Failed to create new function: database error because reason"
+      }
+    }
+
+    assert render(CoreWeb.ErrorView, "create_db_aborted.json", reason: "reason") == out
   end
 end

--- a/apps/core_web/test/core_web/views/fn_view_test.exs
+++ b/apps/core_web/test/core_web/views/fn_view_test.exs
@@ -1,0 +1,25 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule CoreWeb.FnViewTest do
+  use CoreWeb.ConnCase, async: true
+
+  # Bring render/3 and render_to_string/3 for testing custom views
+  import Phoenix.View
+
+  test "create.json" do
+    result = render(CoreWeb.FnView, "create.json", %{function_name: "test"})
+    assert result == %{result: "test"}
+  end
+end

--- a/apps/core_web/test/support/assertion_helpers.ex
+++ b/apps/core_web/test/support/assertion_helpers.ex
@@ -1,0 +1,26 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Support.AssertionHelpers do
+  @moduledoc false
+  import ExUnit.Assertions
+
+  def assert_json_has_correct_keys(lists) do
+    actual = Keyword.fetch!(lists, :actual)
+    refute Enum.empty?(actual)
+
+    expected = Keyword.fetch!(lists, :expected)
+    assert Enum.sort(expected) == Enum.sort(Map.keys(actual))
+  end
+end

--- a/apps/core_web/test/support/conn_case.ex
+++ b/apps/core_web/test/support/conn_case.ex
@@ -37,6 +37,7 @@ defmodule CoreWeb.ConnCase do
       import Plug.Conn
       import Phoenix.ConnTest
       import CoreWeb.ConnCase
+      import Mox
 
       alias CoreWeb.Router.Helpers, as: Routes
 
@@ -46,6 +47,7 @@ defmodule CoreWeb.ConnCase do
   end
 
   setup _tags do
+    Mox.verify_on_exit!()
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 end

--- a/apps/core_web/test/support/conn_case.ex
+++ b/apps/core_web/test/support/conn_case.ex
@@ -37,6 +37,8 @@ defmodule CoreWeb.ConnCase do
       import Plug.Conn
       import Phoenix.ConnTest
       import CoreWeb.ConnCase
+
+      import Support.AssertionHelpers
       import Mox
 
       alias CoreWeb.Router.Helpers, as: Routes

--- a/core-api.yaml
+++ b/core-api.yaml
@@ -51,8 +51,6 @@ components:
           type: string
         code:
           type: string
-        image:
-          type: string
     function_creation_success:
       type: object
       properties:
@@ -87,7 +85,7 @@ components:
           description: The error message
 
 paths:
-  /fn/invoke:
+  /v1/fn/invoke:
     post:
       summary: Invoke a function
       description: >-
@@ -143,7 +141,7 @@ paths:
               examples:
                 Invocation with no workers:
                   value: '{"error": "Failed to invoke function: no worker available"}'
-  /fn/create:
+  /v1/fn/create:
     post:
       summary: Create a new function
       description: >-
@@ -178,7 +176,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/function_creation_error"
-  /fn/delete:
+  /v1/fn/delete:
     delete:
       summary: Delete a function
       description: >-


### PR DESCRIPTION
This PR starts migrating the previous api in the http adapter to the phoenix app. 
It updates the endpoints in the OpenApi spec to `/v1/fn/...` and removes the image field for the create operation.

It adds in router.ex the api scope for /v1/ and inside the fn scope, so that all the endpoints for /v1/fn are encapsulated there.

it handles  /v1/fn/create requests using a general `FnController` which runs  `Api.Function.new` to store a new function. In case of error it uses a fallback controller which returns an error view. The views are used to encode maps in json and return to the user.

It completes the first task in #80  