### PR TITLE
Implement fn/delete with the phoenix api

### DIFF
--- a/apps/core/lib/core/domain/api/function_repo.ex
+++ b/apps/core/lib/core/domain/api/function_repo.ex
@@ -28,7 +28,7 @@ defmodule Core.Domain.Api.FunctionRepo do
   - `function`: FunctionStruct to be stored.
 
   ## Returns
-  - `{:ok, %{result: function_name}}`: if the function was successfully stored.
+  - `{:ok, function_name}`: if the function was successfully stored.
   - `{:error, :bad_params}`: if the function is not a valid FunctionStruct.
   - `{:error, {:aborted, reason}}`: if the function could not be stored.
   """
@@ -58,11 +58,12 @@ defmodule Core.Domain.Api.FunctionRepo do
   - function: The function struct with the name and namespace of the function to delete.
 
   ## Returns
-  - `{:ok, %{"result" => function_name}}`: if the function was successfully deleted.
+  - `{:ok, function_name}`: if the function was successfully deleted.
   - `{:error, :bad_params}`: if the function is not a valid FunctionStruct.
   - `{:error, {:bad_delete, reason}}`: if the function could not be deleted.
   """
-  @spec delete(FunctionStruct.t()) :: {:ok, String.t()} | {:error, {:bad_delete, any}}
+  @spec delete(FunctionStruct.t()) ::
+          {:ok, String.t()} | {:error, :bad_params} | {:error, {:bad_delete, any}}
   def delete(%{"name" => name, "namespace" => namespace}) do
     Logger.info("API: delete request for function #{name} in namespace #{namespace}")
 

--- a/apps/core_web/lib/core_web/controllers/fn_controller.ex
+++ b/apps/core_web/lib/core_web/controllers/fn_controller.ex
@@ -24,6 +24,12 @@ defmodule CoreWeb.FnController do
       render(conn, "create.json", function_name: function_name)
     end
   end
+
+  def delete(conn, params) do
+    with {:ok, function_name} <- FunctionRepo.delete(params) do
+      render(conn, "delete.json", function_name: function_name)
+    end
+  end
 end
 
 defmodule CoreWeb.FnFallbackController do
@@ -39,7 +45,7 @@ defmodule CoreWeb.FnFallbackController do
     conn
     |> put_status(:bad_request)
     |> put_view(CoreWeb.ErrorView)
-    |> render("create_bad_request.json")
+    |> render("bad_request.json")
   end
 
   def call(conn, {:error, {:bad_insert, reason}}) do
@@ -47,5 +53,12 @@ defmodule CoreWeb.FnFallbackController do
     |> put_status(:service_unavailable)
     |> put_view(CoreWeb.ErrorView)
     |> render("create_db_aborted.json", reason: reason)
+  end
+
+  def call(conn, {:error, {:bad_delete, reason}}) do
+    conn
+    |> put_status(:service_unavailable)
+    |> put_view(CoreWeb.ErrorView)
+    |> render("delete_db_aborted.json", reason: reason)
   end
 end

--- a/apps/core_web/lib/core_web/router.ex
+++ b/apps/core_web/lib/core_web/router.ex
@@ -24,6 +24,8 @@ defmodule CoreWeb.Router do
 
     scope "/fn" do
       post("/create", FnController, :create)
+
+      delete("/delete", FnController, :delete)
     end
   end
 

--- a/apps/core_web/lib/core_web/views/error_view.ex
+++ b/apps/core_web/lib/core_web/views/error_view.ex
@@ -28,14 +28,22 @@ defmodule CoreWeb.ErrorView do
     %{errors: %{detail: Phoenix.Controller.status_message_from_template(template)}}
   end
 
-  def render("create_bad_request.json", _assigns) do
-    %{errors: %{detail: "Failed to create new function: bad request"}}
+  def render("bad_request.json", _assigns) do
+    %{errors: %{detail: "Failed to perform operation: bad request"}}
   end
 
   def render("create_db_aborted.json", %{reason: reason}) do
     %{
       errors: %{
         detail: "Failed to create new function: database error because #{reason}"
+      }
+    }
+  end
+
+  def render("delete_db_aborted.json", %{reason: reason}) do
+    %{
+      errors: %{
+        detail: "Failed to delete function: database error because #{reason}"
       }
     }
   end

--- a/apps/core_web/lib/core_web/views/fn_view.ex
+++ b/apps/core_web/lib/core_web/views/fn_view.ex
@@ -18,4 +18,8 @@ defmodule CoreWeb.FnView do
   def render("create.json", %{function_name: name}) do
     %{result: name}
   end
+
+  def render("delete.json", %{function_name: name}) do
+    %{result: name}
+  end
 end

--- a/apps/core_web/test/core_web/views/error_view_test.exs
+++ b/apps/core_web/test/core_web/views/error_view_test.exs
@@ -27,12 +27,12 @@ defmodule CoreWeb.ErrorViewTest do
              %{errors: %{detail: "Internal Server Error"}}
   end
 
-  test "renders create_bad_request.json" do
+  test "renders bad_request.json" do
     out = %{
-      errors: %{detail: "Failed to create new function: bad request"}
+      errors: %{detail: "Failed to perform operation: bad request"}
     }
 
-    assert render(CoreWeb.ErrorView, "create_bad_request.json", []) == out
+    assert render(CoreWeb.ErrorView, "bad_request.json", []) == out
   end
 
   test "renders create_db_aborted.json" do
@@ -43,5 +43,15 @@ defmodule CoreWeb.ErrorViewTest do
     }
 
     assert render(CoreWeb.ErrorView, "create_db_aborted.json", reason: "reason") == out
+  end
+
+  test "renders delete_db_aborted.json" do
+    out = %{
+      errors: %{
+        detail: "Failed to delete function: database error because reason"
+      }
+    }
+
+    assert render(CoreWeb.ErrorView, "delete_db_aborted.json", reason: "reason") == out
   end
 end

--- a/apps/core_web/test/core_web/views/fn_view_test.exs
+++ b/apps/core_web/test/core_web/views/fn_view_test.exs
@@ -22,4 +22,9 @@ defmodule CoreWeb.FnViewTest do
     result = render(CoreWeb.FnView, "create.json", %{function_name: "test"})
     assert result == %{result: "test"}
   end
+
+  test "delete.json" do
+    result = render(CoreWeb.FnView, "delete.json", %{function_name: "test"})
+    assert result == %{result: "test"}
+  end
 end


### PR DESCRIPTION
This PR completes the second task of #80 

It adds the delete route to delete functions. Changes the error view from create_bad_params to the general bad_params to catch the cases of invalid parameters as well, and adds some other test cases.