### PR TITLE
fn/invoke in phoenix api

### DIFF
--- a/apps/core/lib/core/adapters/commands/test.ex
+++ b/apps/core/lib/core/adapters/commands/test.ex
@@ -16,10 +16,10 @@ defmodule Core.Adapters.Commands.Test do
   @moduledoc false
   @behaviour Core.Domain.Ports.Commands
 
-  alias Core.Domain.ResultStruct
+  alias Core.Domain.IvkResult
 
   @impl true
   def send_invocation_command(_worker, function, _args) do
-    {:ok, %ResultStruct{result: function.name}}
+    {:ok, %IvkResult{result: function.name}}
   end
 end

--- a/apps/core/lib/core/adapters/commands/test.ex
+++ b/apps/core/lib/core/adapters/commands/test.ex
@@ -16,10 +16,10 @@ defmodule Core.Adapters.Commands.Test do
   @moduledoc false
   @behaviour Core.Domain.Ports.Commands
 
-  alias Core.Domain.IvkResult
+  alias Core.Domain.InvokeResult
 
   @impl true
   def send_invocation_command(_worker, function, _args) do
-    {:ok, %IvkResult{result: function.name}}
+    {:ok, %InvokeResult{result: function.name}}
   end
 end

--- a/apps/core/lib/core/adapters/commands/worker.ex
+++ b/apps/core/lib/core/adapters/commands/worker.ex
@@ -19,12 +19,12 @@ defmodule Core.Adapters.Commands.Worker do
   """
   require Logger
   alias Core.Domain.FunctionStruct
-  alias Core.Domain.IvkResult
+  alias Core.Domain.InvokeResult
   @behaviour Core.Domain.Ports.Commands
 
   @impl true
   @spec send_invocation_command(atom(), FunctionStruct.t(), map()) ::
-          {:ok, IvkResult.t()} | {:error, atom}
+          {:ok, InvokeResult.t()} | {:error, atom}
   def send_invocation_command(worker, %FunctionStruct{} = function, args) do
     worker_addr = worker_address(worker)
     cmd = invoke_command(function, args)

--- a/apps/core/lib/core/adapters/commands/worker.ex
+++ b/apps/core/lib/core/adapters/commands/worker.ex
@@ -19,12 +19,12 @@ defmodule Core.Adapters.Commands.Worker do
   """
   require Logger
   alias Core.Domain.FunctionStruct
-  alias Core.Domain.ResultStruct
+  alias Core.Domain.IvkResult
   @behaviour Core.Domain.Ports.Commands
 
   @impl true
   @spec send_invocation_command(atom(), FunctionStruct.t(), map()) ::
-          {:ok, ResultStruct.t()} | {:error, atom}
+          {:ok, IvkResult.t()} | {:error, atom}
   def send_invocation_command(worker, %FunctionStruct{} = function, args) do
     worker_addr = worker_address(worker)
     cmd = invoke_command(function, args)

--- a/apps/core/lib/core/adapters/telemetry/native/collector.ex
+++ b/apps/core/lib/core/adapters/telemetry/native/collector.ex
@@ -46,7 +46,6 @@ defmodule Core.Adapters.Telemetry.Native.Collector do
     with :ok <- find_telemetry_process(worker),
          {:ok, metrics} <- pull_metrics(worker),
          {:ok, _} <- save_metrics_with_timestamp(worker, metrics) do
-      Logger.info("Telemetry Collector: metrics pulled from #{worker}")
     else
       {:error, reason} ->
         Logger.warn("Telemetry Collector: error pulling metrics #{inspect(reason)}")

--- a/apps/core/lib/core/adapters/telemetry/native/ets_server.ex
+++ b/apps/core/lib/core/adapters/telemetry/native/ets_server.ex
@@ -36,7 +36,6 @@ defmodule Core.Adapters.Telemetry.Native.EtsServer do
   @impl true
   def handle_call({:insert, worker_node, resources}, _from, table) do
     :ets.insert(table, {worker_node, resources})
-    Logger.info("Telemetry ETS Server: added #{worker_node}")
     {:reply, {:ok, {worker_node, resources}}, table}
   end
 

--- a/apps/core/lib/core/domain/api/invoker.ex
+++ b/apps/core/lib/core/domain/api/invoker.ex
@@ -21,7 +21,7 @@ defmodule Core.Domain.Api.Invoker do
   alias Core.Domain.Nodes
   alias Core.Domain.Ports.Commands
   alias Core.Domain.Ports.FunctionStorage
-  alias Core.Domain.ResultStruct
+  alias Core.Domain.IvkResult
   alias Core.Domain.Scheduler
 
   @doc """
@@ -41,7 +41,7 @@ defmodule Core.Domain.Api.Invoker do
   - {:error, :worker_error} if the worker returned an error.
   """
   @spec invoke(InvokeParams.t()) ::
-          {:ok, ResultStruct.t()}
+          {:ok, IvkResult.t()}
           | {:error, :bad_params}
           | {:error, :not_found}
           | {:error, :no_workers}
@@ -64,7 +64,7 @@ defmodule Core.Domain.Api.Invoker do
   def invoke(_), do: {:error, :bad_params}
 
   @spec invoke_on_chosen(atom(), InvokeParams.t()) ::
-          {:ok, ResultStruct.t()}
+          {:ok, IvkResult.t()}
           | {:error, :not_found}
           | {:error, :no_workers}
           | {:error, :worker_error}
@@ -79,8 +79,8 @@ defmodule Core.Domain.Api.Invoker do
 
     case f do
       {:ok, function} ->
-        wrk_reply = Commands.send_invocation_command(worker, function, ivk_params.args)
-        parse_wrk_reply(wrk_reply)
+        Commands.send_invocation_command(worker, function, ivk_params.args)
+        |> parse_wrk_reply
 
       {:error, :not_found} ->
         fun = ivk_params.function
@@ -91,8 +91,8 @@ defmodule Core.Domain.Api.Invoker do
     end
   end
 
-  @spec parse_wrk_reply({:ok, ResultStruct.t()} | {:error, any}) ::
-          {:ok, ResultStruct.t()} | {:error, :worker_error}
+  @spec parse_wrk_reply({:ok, IvkResult.t()} | {:error, any}) ::
+          {:ok, IvkResult.t()} | {:error, :worker_error}
   defp parse_wrk_reply({:ok, _} = reply) do
     Logger.info("API: received success reply from worker")
     reply

--- a/apps/core/lib/core/domain/api/invoker.ex
+++ b/apps/core/lib/core/domain/api/invoker.ex
@@ -18,10 +18,10 @@ defmodule Core.Domain.Api.Invoker do
   """
   require Logger
   alias Core.Domain.InvokeParams
+  alias Core.Domain.InvokeResult
   alias Core.Domain.Nodes
   alias Core.Domain.Ports.Commands
   alias Core.Domain.Ports.FunctionStorage
-  alias Core.Domain.IvkResult
   alias Core.Domain.Scheduler
 
   @doc """
@@ -41,7 +41,7 @@ defmodule Core.Domain.Api.Invoker do
   - {:error, :worker_error} if the worker returned an error.
   """
   @spec invoke(InvokeParams.t()) ::
-          {:ok, IvkResult.t()}
+          {:ok, InvokeResult.t()}
           | {:error, :bad_params}
           | {:error, :not_found}
           | {:error, :no_workers}
@@ -64,7 +64,7 @@ defmodule Core.Domain.Api.Invoker do
   def invoke(_), do: {:error, :bad_params}
 
   @spec invoke_on_chosen(atom(), InvokeParams.t()) ::
-          {:ok, IvkResult.t()}
+          {:ok, InvokeResult.t()}
           | {:error, :not_found}
           | {:error, :no_workers}
           | {:error, :worker_error}
@@ -91,8 +91,8 @@ defmodule Core.Domain.Api.Invoker do
     end
   end
 
-  @spec parse_wrk_reply({:ok, IvkResult.t()} | {:error, any}) ::
-          {:ok, IvkResult.t()} | {:error, :worker_error}
+  @spec parse_wrk_reply({:ok, InvokeResult.t()} | {:error, any}) ::
+          {:ok, InvokeResult.t()} | {:error, :worker_error}
   defp parse_wrk_reply({:ok, _} = reply) do
     Logger.info("API: received success reply from worker")
     reply

--- a/apps/core/lib/core/domain/ports/commands.ex
+++ b/apps/core/lib/core/domain/ports/commands.ex
@@ -17,7 +17,7 @@ defmodule Core.Domain.Ports.Commands do
   Port for sending commands to workers.
   """
 
-  alias Core.Domain.IvkResult
+  alias Core.Domain.InvokeResult
 
   @type worker :: atom()
   @type fl_function :: Core.Domain.FunctionStruct.t()
@@ -25,7 +25,7 @@ defmodule Core.Domain.Ports.Commands do
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
   @callback send_invocation_command(worker, fl_function, map()) ::
-              {:ok, IvkResult.t()} | {:error, atom}
+              {:ok, InvokeResult.t()} | {:error, atom}
 
   @doc """
   Sends an invocation command to a worker.
@@ -33,6 +33,6 @@ defmodule Core.Domain.Ports.Commands do
   (optionally empty) function arguments.
   """
   @spec send_invocation_command(worker, fl_function, map()) ::
-          {:ok, IvkResult.t()} | {:error, atom}
+          {:ok, InvokeResult.t()} | {:error, atom}
   defdelegate send_invocation_command(worker, function, args), to: @adapter
 end

--- a/apps/core/lib/core/domain/ports/commands.ex
+++ b/apps/core/lib/core/domain/ports/commands.ex
@@ -17,7 +17,7 @@ defmodule Core.Domain.Ports.Commands do
   Port for sending commands to workers.
   """
 
-  alias Core.Domain.ResultStruct
+  alias Core.Domain.IvkResult
 
   @type worker :: atom()
   @type fl_function :: Core.Domain.FunctionStruct.t()
@@ -25,7 +25,7 @@ defmodule Core.Domain.Ports.Commands do
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
   @callback send_invocation_command(worker, fl_function, map()) ::
-              {:ok, ResultStruct.t()} | {:error, atom}
+              {:ok, IvkResult.t()} | {:error, atom}
 
   @doc """
   Sends an invocation command to a worker.
@@ -33,6 +33,6 @@ defmodule Core.Domain.Ports.Commands do
   (optionally empty) function arguments.
   """
   @spec send_invocation_command(worker, fl_function, map()) ::
-          {:ok, ResultStruct.t()} | {:error, atom}
+          {:ok, IvkResult.t()} | {:error, atom}
   defdelegate send_invocation_command(worker, function, args), to: @adapter
 end

--- a/apps/core/lib/core/domain/structs.ex
+++ b/apps/core/lib/core/domain/structs.ex
@@ -50,7 +50,7 @@ defmodule Core.Domain.InvokeParams do
   defstruct [:function, namespace: "_", args: %{}]
 end
 
-defmodule Core.Domain.IvkResult do
+defmodule Core.Domain.InvokeResult do
   @moduledoc """
   Result struct used for operation results (create/invoke/delete).
   """

--- a/apps/core/lib/core/domain/structs.ex
+++ b/apps/core/lib/core/domain/structs.ex
@@ -19,13 +19,13 @@ defmodule Core.Domain.FunctionStruct do
     ## Fields
       - name: function name
       - namespace: function namespace
-      - code: function code as a string
+      - code: function code as a string or binary
       - image: runtime image corresponding to the language with which the function is written
   """
   @type t :: %__MODULE__{
           namespace: String.t(),
           name: String.t(),
-          code: String.t(),
+          code: String.t() | binary(),
           image: String.t()
         }
   @enforce_keys [:name, :namespace, :code]
@@ -50,14 +50,11 @@ defmodule Core.Domain.InvokeParams do
   defstruct [:function, namespace: "_", args: %{}]
 end
 
-defmodule Core.Domain.ResultStruct do
+defmodule Core.Domain.IvkResult do
   @moduledoc """
   Result struct used for operation results (create/invoke/delete).
   """
-  @derive Jason.Encoder
-  @type t :: %__MODULE__{
-          result: any
-        }
+  @type t :: %__MODULE__{result: any()}
   @enforce_keys [:result]
   defstruct [:result]
 end

--- a/apps/core/test/unit/api_test/invoke_test.exs
+++ b/apps/core/test/unit/api_test/invoke_test.exs
@@ -14,11 +14,11 @@
 
 defmodule ApiTest.InvokeTest do
   alias Core.Domain.Api
+  alias Core.Domain.IvkResult
 
   use ExUnit.Case, async: true
   import Mox, only: [verify_on_exit!: 1]
   use Plug.Test
-  alias Core.Domain.ResultStruct
 
   setup :verify_on_exit!
 
@@ -39,7 +39,7 @@ defmodule ApiTest.InvokeTest do
     test "invoke should return {:ok, result} when there is at least a worker and no error occurs" do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
-      assert Api.Invoker.invoke(%{"function" => "test"}) == {:ok, %ResultStruct{result: "test"}}
+      assert Api.Invoker.invoke(%{"function" => "test"}) == {:ok, %IvkResult{result: "test"}}
     end
 
     test "invoke should return {:error, err} when the invocation on worker encounter errors" do

--- a/apps/core/test/unit/api_test/invoke_test.exs
+++ b/apps/core/test/unit/api_test/invoke_test.exs
@@ -14,7 +14,7 @@
 
 defmodule ApiTest.InvokeTest do
   alias Core.Domain.Api
-  alias Core.Domain.IvkResult
+  alias Core.Domain.InvokeResult
 
   use ExUnit.Case, async: true
   import Mox, only: [verify_on_exit!: 1]
@@ -39,7 +39,7 @@ defmodule ApiTest.InvokeTest do
     test "invoke should return {:ok, result} when there is at least a worker and no error occurs" do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
-      assert Api.Invoker.invoke(%{"function" => "test"}) == {:ok, %IvkResult{result: "test"}}
+      assert Api.Invoker.invoke(%{"function" => "test"}) == {:ok, %InvokeResult{result: "test"}}
     end
 
     test "invoke should return {:error, err} when the invocation on worker encounter errors" do

--- a/apps/core_web/lib/core_web/controllers/fn_controller.ex
+++ b/apps/core_web/lib/core_web/controllers/fn_controller.ex
@@ -52,13 +52,13 @@ defmodule CoreWeb.FnFallbackController do
     conn
     |> put_status(:service_unavailable)
     |> put_view(CoreWeb.ErrorView)
-    |> render("create_db_aborted.json", reason: reason)
+    |> render("db_aborted.json", action: "create", reason: reason)
   end
 
   def call(conn, {:error, {:bad_delete, reason}}) do
     conn
     |> put_status(:service_unavailable)
     |> put_view(CoreWeb.ErrorView)
-    |> render("delete_db_aborted.json", reason: reason)
+    |> render("delete_db_aborted.json", action: "delete", reason: reason)
   end
 end

--- a/apps/core_web/lib/core_web/endpoint.ex
+++ b/apps/core_web/lib/core_web/endpoint.ex
@@ -24,7 +24,7 @@ defmodule CoreWeb.Endpoint do
     signing_salt: "8P0asjT/"
   ]
 
-  # socket("/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]])
+  socket("/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]])
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/apps/core_web/lib/core_web/router.ex
+++ b/apps/core_web/lib/core_web/router.ex
@@ -24,8 +24,9 @@ defmodule CoreWeb.Router do
 
     scope "/fn" do
       post("/create", FnController, :create)
-
       delete("/delete", FnController, :delete)
+
+      post("/invoke", FnController, :invoke)
     end
   end
 

--- a/apps/core_web/lib/core_web/views/error_view.ex
+++ b/apps/core_web/lib/core_web/views/error_view.ex
@@ -32,19 +32,8 @@ defmodule CoreWeb.ErrorView do
     %{errors: %{detail: "Failed to perform operation: bad request"}}
   end
 
-  def render("create_db_aborted.json", %{reason: reason}) do
-    %{
-      errors: %{
-        detail: "Failed to create new function: database error because #{reason}"
-      }
-    }
-  end
-
-  def render("delete_db_aborted.json", %{reason: reason}) do
-    %{
-      errors: %{
-        detail: "Failed to delete function: database error because #{reason}"
-      }
-    }
+  def render("db_aborted.json", %{action: action, reason: reason}) do
+    message = "Failed to #{action} function: database error because #{reason}"
+    %{errors: %{detail: message}}
   end
 end

--- a/apps/core_web/lib/core_web/views/error_view.ex
+++ b/apps/core_web/lib/core_web/views/error_view.ex
@@ -32,8 +32,20 @@ defmodule CoreWeb.ErrorView do
     %{errors: %{detail: "Failed to perform operation: bad request"}}
   end
 
+  def render("function_not_found.json", _assigns) do
+    %{errors: %{detail: "Failed to invoke function: not found in given namespace"}}
+  end
+
   def render("db_aborted.json", %{action: action, reason: reason}) do
     message = "Failed to #{action} function: database error because #{reason}"
     %{errors: %{detail: message}}
+  end
+
+  def render("no_workers.json", _assigns) do
+    %{errors: %{detail: "Failed to perform operation: no worker available"}}
+  end
+
+  def render("worker_error.json", _assigns) do
+    %{errors: %{detail: "Failed to perform operation: worker error"}}
   end
 end

--- a/apps/core_web/lib/core_web/views/fn_view.ex
+++ b/apps/core_web/lib/core_web/views/fn_view.ex
@@ -15,11 +15,9 @@
 defmodule CoreWeb.FnView do
   use CoreWeb, :view
 
-  def render("create.json", %{function_name: name}) do
-    %{result: name}
-  end
+  def render("invoke.json", %{result: ivk_res}), do: %{result: ivk_res}
 
-  def render("delete.json", %{function_name: name}) do
-    %{result: name}
-  end
+  def render("create.json", %{function_name: name}), do: %{result: name}
+
+  def render("delete.json", %{function_name: name}), do: %{result: name}
 end

--- a/apps/core_web/test/core_web/controllers/fn_controller_test.exs
+++ b/apps/core_web/test/core_web/controllers/fn_controller_test.exs
@@ -48,26 +48,18 @@ defmodule CoreWeb.FnControllerTest do
       Core.FunctionStorage.Mock |> Mox.expect(:get_function, fn _, _ -> {:error, :not_found} end)
 
       conn = post(conn, "/v1/fn/invoke", %{function: "hello"})
-
-      assert body = json_response(conn, 404)
-      expected_error_keys = ["detail"]
-      assert_json_has_correct_keys(actual: body["errors"], expected: expected_error_keys)
+      assert json_response(conn, 404) |> assert_error_keys
     end
 
     test "error: should return 400 bad request when bad parameters", %{conn: conn} do
       conn = post(conn, "/v1/fn/invoke", %{bad: "param"})
-      assert body = json_response(conn, 400)
-      expected_error_keys = ["detail"]
-      assert_json_has_correct_keys(actual: body["errors"], expected: expected_error_keys)
+      assert json_response(conn, 400) |> assert_error_keys
     end
 
     test "error: should returns 400 when missing parameters", %{conn: conn} do
       conn = post(conn, "/v1/fn/invoke", %{namespace: "a_ns"})
 
-      assert body = json_response(conn, 400)
-      expected_error_keys = ["detail"]
-
-      assert_json_has_correct_keys(actual: body["errors"], expected: expected_error_keys)
+      assert json_response(conn, 400) |> assert_error_keys
     end
 
     test "error: should return 500 when some worker error occurs", %{conn: conn} do
@@ -80,31 +72,19 @@ defmodule CoreWeb.FnControllerTest do
 
       conn = post(conn, "/v1/fn/invoke", %{function: "test", code: ""})
 
-      assert body = json_response(conn, 500)
-      expected_error_keys = ["detail"]
-
-      assert_json_has_correct_keys(actual: body["errors"], expected: expected_error_keys)
+      assert json_response(conn, 500) |> assert_error_keys
     end
 
     test "error: should return 503 when invocation with no workers available fails", %{conn: conn} do
       conn = post(conn, "/v1/fn/invoke", %{function: "test", code: ""})
 
-      assert body = json_response(conn, 503)
-      expected_error_keys = ["detail"]
-
-      assert_json_has_correct_keys(actual: body["errors"], expected: expected_error_keys)
+      assert json_response(conn, 503) |> assert_error_keys
     end
   end
 
   describe "POST /v1/fn/create" do
     test "success: should return 200 when the creation is successful", %{conn: conn} do
-      conn =
-        conn
-        |> post("/v1/fn/create", %{
-          "name" => "hello",
-          "namespace" => "ns",
-          "code" => "some code"
-        })
+      conn = post(conn, "/v1/fn/create", %{name: "hello", code: "some code"})
 
       assert body = json_response(conn, 200)
       expected_keys = ["result"]
@@ -115,19 +95,13 @@ defmodule CoreWeb.FnControllerTest do
     test "error: should returns 400 when given invalid parameters", %{conn: conn} do
       conn = post(conn, "/v1/fn/create", %{bad: "params"})
 
-      assert body = json_response(conn, 400)
-      expected_error_keys = ["detail"]
-
-      assert_json_has_correct_keys(actual: body["errors"], expected: expected_error_keys)
+      assert json_response(conn, 400) |> assert_error_keys
     end
 
     test "error: should returns 400 when missing parameters", %{conn: conn} do
       conn = post(conn, "/v1/fn/create", %{name: "a_function"})
 
-      assert body = json_response(conn, 400)
-      expected_error_keys = ["detail"]
-
-      assert_json_has_correct_keys(actual: body["errors"], expected: expected_error_keys)
+      assert json_response(conn, 400) |> assert_error_keys
     end
 
     test "error: should return 503 when the underlying storage transaction fails", %{conn: conn} do
@@ -136,10 +110,7 @@ defmodule CoreWeb.FnControllerTest do
 
       conn = post(conn, "/v1/fn/create", %{name: "hello", code: "some code"})
 
-      assert body = json_response(conn, 503)
-      expected_error_keys = ["detail"]
-
-      assert_json_has_correct_keys(actual: body["errors"], expected: expected_error_keys)
+      assert json_response(conn, 503) |> assert_error_keys
     end
   end
 
@@ -149,26 +120,19 @@ defmodule CoreWeb.FnControllerTest do
 
       assert body = json_response(conn, 200)
       expected_keys = ["result"]
-
       assert_json_has_correct_keys(actual: body, expected: expected_keys)
     end
 
     test "error: should return 400 when given bad parameters", %{conn: conn} do
       conn = delete(conn, "/v1/fn/delete", %{bad: "params"})
 
-      assert body = json_response(conn, 400)
-      expected_error_keys = ["detail"]
-
-      assert_json_has_correct_keys(actual: body["errors"], expected: expected_error_keys)
+      assert json_response(conn, 400) |> assert_error_keys
     end
 
     test "error: should return 400 when missing parameters", %{conn: conn} do
       conn = delete(conn, "/v1/fn/delete", %{namespace: "a_ns"})
 
-      assert body = json_response(conn, 400)
-      expected_error_keys = ["detail"]
-
-      assert_json_has_correct_keys(actual: body["errors"], expected: expected_error_keys)
+      assert json_response(conn, 400) |> assert_error_keys
     end
 
     test "error: should return 503 when the underlying storage transaction fails", %{conn: conn} do
@@ -177,10 +141,7 @@ defmodule CoreWeb.FnControllerTest do
 
       conn = delete(conn, "/v1/fn/delete", %{name: "hello", namespace: "ns"})
 
-      assert body = json_response(conn, 503)
-      expected_error_keys = ["detail"]
-
-      assert_json_has_correct_keys(actual: body["errors"], expected: expected_error_keys)
+      assert json_response(conn, 503) |> assert_error_keys
     end
   end
 end

--- a/apps/core_web/test/core_web/views/error_view_test.exs
+++ b/apps/core_web/test/core_web/views/error_view_test.exs
@@ -23,36 +23,38 @@ defmodule CoreWeb.ErrorViewTest do
   end
 
   test "renders 500.json" do
-    assert render(CoreWeb.ErrorView, "500.json", []) ==
-             %{errors: %{detail: "Internal Server Error"}}
+    assert render(CoreWeb.ErrorView, "500.json", []) == %{
+             errors: %{detail: "Internal Server Error"}
+           }
   end
 
   test "renders bad_request.json" do
-    out = %{
-      errors: %{detail: "Failed to perform operation: bad request"}
-    }
-
+    out = %{errors: %{detail: "Failed to perform operation: bad request"}}
     assert render(CoreWeb.ErrorView, "bad_request.json", []) == out
   end
 
-  test "renders db_aborted.json for create function" do
-    out = %{
-      errors: %{
-        detail: "Failed to create function: database error because reason"
-      }
-    }
+  test "renders function_not_found.json" do
+    out = %{errors: %{detail: "Failed to invoke function: not found in given namespace"}}
+    assert render(CoreWeb.ErrorView, "function_not_found.json", []) == out
+  end
 
+  test "renders no_workers.json" do
+    out = %{errors: %{detail: "Failed to perform operation: no worker available"}}
+    assert render(CoreWeb.ErrorView, "no_workers.json", []) == out
+  end
+
+  test "renders worker_error.json" do
+    out = %{errors: %{detail: "Failed to perform operation: worker error"}}
+    assert render(CoreWeb.ErrorView, "worker_error.json", []) == out
+  end
+
+  test "renders db_aborted.json for create function" do
+    out = %{errors: %{detail: "Failed to create function: database error because reason"}}
     assert render(CoreWeb.ErrorView, "db_aborted.json", action: "create", reason: "reason") == out
   end
 
   test "renders db_aborted.json for delete" do
-    out = %{
-      errors: %{
-        detail: "Failed to delete function: database error because reason"
-      }
-    }
-
-    assert render(CoreWeb.ErrorView, "db_aborted.json", action: "delete", reason: "reason") ==
-             out
+    out = %{errors: %{detail: "Failed to delete function: database error because reason"}}
+    assert render(CoreWeb.ErrorView, "db_aborted.json", action: "delete", reason: "reason") == out
   end
 end

--- a/apps/core_web/test/core_web/views/error_view_test.exs
+++ b/apps/core_web/test/core_web/views/error_view_test.exs
@@ -35,23 +35,24 @@ defmodule CoreWeb.ErrorViewTest do
     assert render(CoreWeb.ErrorView, "bad_request.json", []) == out
   end
 
-  test "renders create_db_aborted.json" do
+  test "renders db_aborted.json for create function" do
     out = %{
       errors: %{
-        detail: "Failed to create new function: database error because reason"
+        detail: "Failed to create function: database error because reason"
       }
     }
 
-    assert render(CoreWeb.ErrorView, "create_db_aborted.json", reason: "reason") == out
+    assert render(CoreWeb.ErrorView, "db_aborted.json", action: "create", reason: "reason") == out
   end
 
-  test "renders delete_db_aborted.json" do
+  test "renders db_aborted.json for delete" do
     out = %{
       errors: %{
         detail: "Failed to delete function: database error because reason"
       }
     }
 
-    assert render(CoreWeb.ErrorView, "delete_db_aborted.json", reason: "reason") == out
+    assert render(CoreWeb.ErrorView, "db_aborted.json", action: "delete", reason: "reason") ==
+             out
   end
 end

--- a/apps/core_web/test/core_web/views/fn_view_test.exs
+++ b/apps/core_web/test/core_web/views/fn_view_test.exs
@@ -18,6 +18,11 @@ defmodule CoreWeb.FnViewTest do
   # Bring render/3 and render_to_string/3 for testing custom views
   import Phoenix.View
 
+  test "invoke.json" do
+    result = render(CoreWeb.FnView, "invoke.json", %{result: "result"})
+    assert result == %{result: "result"}
+  end
+
   test "create.json" do
     result = render(CoreWeb.FnView, "create.json", %{function_name: "test"})
     assert result == %{result: "test"}

--- a/apps/core_web/test/support/assertion_helpers.ex
+++ b/apps/core_web/test/support/assertion_helpers.ex
@@ -16,6 +16,12 @@ defmodule Support.AssertionHelpers do
   @moduledoc false
   import ExUnit.Assertions
 
+  def assert_error_keys(json) do
+    actual_errors = json["errors"]
+    expected_error_keys = ["detail"]
+    assert_json_has_correct_keys(actual: actual_errors, expected: expected_error_keys)
+  end
+
   def assert_json_has_correct_keys(lists) do
     actual = Keyword.fetch!(lists, :actual)
     refute Enum.empty?(actual)

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,9 +26,12 @@ config :logger, :console,
 
 config :libcluster,
   topologies: [
-    funless: [
+    funless_core: [
       # The selected clustering strategy. Required.
-      strategy: Cluster.Strategy.Gossip
+      strategy: Cluster.Strategy.Gossip,
+      config: [
+        port: 45891
+      ]
     ]
   ]
 
@@ -39,10 +42,10 @@ config :core_web,
 config :core_web, CoreWeb.Endpoint,
   url: [host: "localhost"],
   render_errors: [view: CoreWeb.ErrorView, accepts: ~w(json), layout: false],
+  live_view: [signing_salt: "sRzweIOe"],
   adapter: Bandit.PhoenixAdapter
 
 # pubsub_server: Core.PubSub,
-# live_view: [signing_salt: "sRzweIOe"],
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -37,7 +37,7 @@ config :logger, :info_log,
 # which you should run after static files are built and
 # before starting your production server.
 config :core_web, CoreWeb.Endpoint,
-  url: [host: "example.com", port: 80],
+  url: [host: "localhost", port: 4000],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 # ## SSL Support

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,15 @@ defmodule Core.Umbrella.MixProject do
         flags: ["-Wunmatched_returns", :error_handling, :underspecs]
       ],
       deps: deps(),
-      aliases: aliases()
+      aliases: aliases(),
+      releases: [
+        core: [
+          applications: [
+            core: :permanent,
+            core_web: :permanent
+          ]
+        ]
+      ]
     ]
   end
 


### PR DESCRIPTION
This PR migrates the invoke from the http adapter to the phoenix api. It also does some fixes and adds the releases list to build the project.

It completes the third task of #80.