### PR TITLE
Function creation fix

### DIFF
--- a/apps/core/mix.exs
+++ b/apps/core/mix.exs
@@ -54,7 +54,6 @@ defmodule Core.MixProject do
   defp deps do
     [
       {:plug, "~> 1.13"},
-      {:bandit, "~> 0.5.0"},
       {:jason, "~> 1.3"},
       {:libcluster, "~> 3.3"},
       {:logger_file_backend, "~> 0.0.13"},

--- a/apps/core_web/lib/core_web/controllers/fn_controller.ex
+++ b/apps/core_web/lib/core_web/controllers/fn_controller.ex
@@ -27,7 +27,9 @@ defmodule CoreWeb.FnController do
   end
 
   def create(conn, params) do
-    with {:ok, function_name} <- FunctionRepo.new(params) do
+    func = params |> Map.put("code", File.read!(params["code"].path))
+
+    with {:ok, function_name} <- FunctionRepo.new(func) do
       conn
       |> put_status(:created)
       |> render("create.json", function_name: function_name)

--- a/apps/core_web/lib/core_web/controllers/fn_controller.ex
+++ b/apps/core_web/lib/core_web/controllers/fn_controller.ex
@@ -26,14 +26,18 @@ defmodule CoreWeb.FnController do
     end
   end
 
-  def create(conn, params) do
-    func = params |> Map.put("code", File.read!(params["code"].path))
+  def create(conn, %{"code" => %Plug.Upload{path: tmp_code_path}} = params) do
+    func = params |> Map.put("code", File.read!(tmp_code_path))
 
     with {:ok, function_name} <- FunctionRepo.new(func) do
       conn
       |> put_status(:created)
       |> render("create.json", function_name: function_name)
     end
+  end
+
+  def create(_conn, _params) do
+    {:error, :bad_params}
   end
 
   def delete(conn, params) do

--- a/apps/core_web/mix.exs
+++ b/apps/core_web/mix.exs
@@ -57,7 +57,8 @@ defmodule CoreWeb.MixProject do
       {:telemetry_metrics, "~> 0.6"},
       {:telemetry_poller, "~> 1.0"},
       {:jason, "~> 1.2"},
-      {:bandit, ">= 0.5.6"}
+      {:cowboy, "~> 2.9.0"},
+      {:plug_cowboy, "~> 2.5.2"}
     ]
   end
 

--- a/apps/core_web/test/core_web/controllers/fn_controller_test.exs
+++ b/apps/core_web/test/core_web/controllers/fn_controller_test.exs
@@ -85,7 +85,9 @@ defmodule CoreWeb.FnControllerTest do
 
   describe "POST /v1/fn/create" do
     test "success: should return 200 when the creation is successful", %{conn: conn} do
-      conn = post(conn, "/v1/fn/create", %{name: "hello", code: "some code"})
+      upload = %Plug.Upload{path: "test/fixtures/test_code.txt", filename: "test_code.txt"}
+      conn = post(conn, "/v1/fn/create", %{name: "hello", code: upload})
+
       expected = %{"result" => "hello"}
       assert json_response(conn, 201) == expected
     end
@@ -106,7 +108,8 @@ defmodule CoreWeb.FnControllerTest do
       Core.FunctionStore.Mock
       |> Mox.expect(:insert_function, fn _ -> {:error, {:aborted, "some reason"}} end)
 
-      conn = post(conn, "/v1/fn/create", %{name: "hello", code: "some code"})
+      upload = %Plug.Upload{path: "test/fixtures/test_code.txt", filename: "test_code.txt"}
+      conn = post(conn, "/v1/fn/create", %{name: "hello", code: upload})
 
       expected = %{
         "errors" => %{"detail" => "Failed to create function: database error because some reason"}
@@ -172,8 +175,10 @@ defmodule CoreWeb.FnControllerTest do
 
       response =
         assert_error_sent(500, fn ->
+          upload = %Plug.Upload{path: "test/fixtures/test_code.txt", filename: "test_code.txt"}
+
           conn
-          |> post("/v1/fn/create", %{name: "hello", namespace: "ns", code: "some code"})
+          |> post("/v1/fn/create", %{name: "hello", namespace: "ns", code: upload})
         end)
 
       assert {500, [_h | _t], "{\"errors\":{\"detail\":\"Internal Server Error\"}}"} = response

--- a/apps/core_web/test/fixtures/test_code.txt
+++ b/apps/core_web/test/fixtures/test_code.txt
@@ -1,0 +1,15 @@
+// Copyright 2022 Giuseppe De Palma, Matteo Trentin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+some code

--- a/config/config.exs
+++ b/config/config.exs
@@ -42,8 +42,7 @@ config :core_web,
 config :core_web, CoreWeb.Endpoint,
   url: [host: "0.0.0.0"],
   render_errors: [view: CoreWeb.ErrorView, accepts: ~w(json), layout: false],
-  live_view: [signing_salt: "sRzweIOe"],
-  adapter: Bandit.PhoenixAdapter
+  live_view: [signing_salt: "sRzweIOe"]
 
 # pubsub_server: Core.PubSub,
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,7 @@ config :libcluster,
       # The selected clustering strategy. Required.
       strategy: Cluster.Strategy.Gossip,
       config: [
-        port: 45891
+        port: String.to_integer(System.get_env("FL_LIBCLUSTER_PORT") || "45892")
       ]
     ]
   ]


### PR DESCRIPTION
This PR fixes function creation after the modification made to `core-api.yml`.
Specifically, it handles file upload and reverts the Phoenix adapter back to Cowboy.

Additionally it adds the possibility of giving libcluster a custom port, while leaving the default one unchanged.