### PR TITLE
404 response for delete

### DIFF
--- a/apps/core/lib/core/adapters/function_store/mnesia.ex
+++ b/apps/core/lib/core/adapters/function_store/mnesia.ex
@@ -83,17 +83,13 @@ defmodule Core.Adapters.FunctionStore.Mnesia do
   @impl true
   @spec delete_function(String.t(), String.t()) :: {:ok, String.t()} | {:error, {:aborted, any}}
   def delete_function(f_name, f_namespace) do
-    if exists?(f_name, f_namespace) do
-      data = fn ->
-        :mnesia.delete({FunctionStruct, {f_name, f_namespace}})
-      end
+    data = fn ->
+      :mnesia.delete({FunctionStruct, {f_name, f_namespace}})
+    end
 
-      case :mnesia.transaction(data) do
-        {:aborted, reason} -> {:error, {:aborted, reason}}
-        {_, :ok} -> {:ok, f_name}
-      end
-    else
-      {:error, {:aborted, "function #{f_name} from namespace #{f_namespace} not found"}}
+    case :mnesia.transaction(data) do
+      {:aborted, reason} -> {:error, {:aborted, reason}}
+      {_, :ok} -> {:ok, f_name}
     end
   end
 end

--- a/apps/core/lib/core/domain/api/function_repo.ex
+++ b/apps/core/lib/core/domain/api/function_repo.ex
@@ -66,8 +66,14 @@ defmodule Core.Domain.Api.FunctionRepo do
   def delete(%{"name" => name, "namespace" => namespace}) do
     Logger.info("API: delete request for function #{name} in namespace #{namespace}")
 
-    FunctionStore.delete_function(name, namespace)
-    |> parse_delete_result(name)
+    case FunctionStore.exists?(name, namespace) do
+      true ->
+        FunctionStore.delete_function(name, namespace)
+        |> parse_delete_result(name)
+
+      false ->
+        {:error, {:bad_delete, :not_found}}
+    end
   end
 
   def delete(_), do: {:error, :bad_params}

--- a/apps/core/test/integration/mnesia_store_test.exs
+++ b/apps/core/test/integration/mnesia_store_test.exs
@@ -61,11 +61,6 @@ defmodule MnesiaStoreTest do
       assert {:ok, "test-name"} == Mnesia.delete_function("test-name", "ns")
     end
 
-    test "delete_function should return {:error, {:aborted, reason}} when delete on non-existing function" do
-      res = Mnesia.delete_function("test-name-not-in-store", "ns")
-      assert {:error, {:aborted, _}} = res
-    end
-
     test "insert_function should return {:error, {:aborted, reason}} when insert fails", %{f: f} do
       # Test with mnesia stopped so it fails to insert
       :mnesia.stop()

--- a/apps/core_web/lib/core_web/controllers/fn_controller.ex
+++ b/apps/core_web/lib/core_web/controllers/fn_controller.ex
@@ -90,16 +90,24 @@ defmodule CoreWeb.FnFallbackController do
     |> json(res)
   end
 
-  def call(conn, {:error, {kind, reason}}) when kind == :bad_insert or kind == :bad_delete do
-    action =
-      if kind == :bad_insert do
-        "create"
-      else
-        "delete"
-      end
+  def call(conn, {:error, {:bad_insert, reason}}) do
+    res = %{errors: %{detail: "Failed to create function: #{reason}"}}
 
-    message = "Failed to #{action} function: database error because #{reason}"
-    res = %{errors: %{detail: message}}
+    conn
+    |> put_status(:service_unavailable)
+    |> json(res)
+  end
+
+  def call(conn, {:error, {:bad_delete, :not_found}}) do
+    res = %{errors: %{detail: "Failed to delete function: not found"}}
+
+    conn
+    |> put_status(:not_found)
+    |> json(res)
+  end
+
+  def call(conn, {:error, {:bad_delete, reason}}) do
+    res = %{errors: %{detail: "Failed to delete function: #{reason}"}}
 
     conn
     |> put_status(:service_unavailable)

--- a/core-api.yaml
+++ b/core-api.yaml
@@ -208,6 +208,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/function_deletion_error"
+        "404":
+          description: The function to delete was not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/function_deletion_error"
         "503":
           description: The function deletion request failed because the database transaction was aborted
           content:


### PR DESCRIPTION
This PR closes #104 

It updates function_repo tests and moves the exists check in the domain.
The core_web controller adds a pattern matching clause for the bad_delete in case of not found to return a 404 response.