### PR TITLE
Deployment on kind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ FROM alpine:${ALPINE_VERSION}
 
 ARG MIX_ENV=prod
 ARG PORT=4000
+ARG NODE_IP=""
 
 # # The name of your application/release (required)
 RUN apk update && \
@@ -55,7 +56,8 @@ RUN apk update && \
 
 ENV REPLACE_OS_VARS=true \
     MIX_ENV=${MIX_ENV} \ 
-    PORT=${PORT} 
+    PORT=${PORT} \
+    NODE_IP=${NODE_IP}
 
 WORKDIR /home/funless
 RUN adduser --disabled-password --home "$(pwd)" funless &&\
@@ -65,4 +67,4 @@ USER funless
 
 COPY --chown=funless --from=builder /opt/app/_build/${MIX_ENV}/rel/core ./core
 
-CMD PORT=${PORT} core/bin/core start
+CMD if [[ -z "$NODE_IP" ]] ; then PORT=${PORT} core/bin/core start ; else RELEASE_NODE=core@${NODE_IP} PORT=${PORT} core/bin/core start ; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ FROM alpine:${ALPINE_VERSION}
 ARG MIX_ENV=prod
 ARG PORT=4000
 ARG NODE_IP=""
+ARG DEPLOY_ENV=""
 
 # # The name of your application/release (required)
 RUN apk update && \
@@ -57,7 +58,8 @@ RUN apk update && \
 ENV REPLACE_OS_VARS=true \
     MIX_ENV=${MIX_ENV} \ 
     PORT=${PORT} \
-    NODE_IP=${NODE_IP}
+    NODE_IP=${NODE_IP} \
+    DEPLOY_ENV=${DEPLOY_ENV}
 
 WORKDIR /home/funless
 RUN adduser --disabled-password --home "$(pwd)" funless &&\
@@ -67,4 +69,7 @@ USER funless
 
 COPY --chown=funless --from=builder /opt/app/_build/${MIX_ENV}/rel/core ./core
 
-CMD if [[ -z "$NODE_IP" ]] ; then PORT=${PORT} core/bin/core start ; else RELEASE_NODE=core@${NODE_IP} PORT=${PORT} core/bin/core start ; fi
+CMD if [[ -z "$NODE_IP" ]] ; \
+    then PORT=${PORT} DEPLOY_ENV=${DEPLOY_ENV} core/bin/core start ; \
+    else RELEASE_NODE=core@${NODE_IP} PORT=${PORT} DEPLOY_ENV=${DEPLOY_ENV} core/bin/core start ; \
+    fi

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,17 +24,6 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id, :file, :line]
 
-config :libcluster,
-  topologies: [
-    funless_core: [
-      # The selected clustering strategy. Required.
-      strategy: Cluster.Strategy.Gossip,
-      config: [
-        port: String.to_integer(System.get_env("FL_LIBCLUSTER_PORT") || "45892")
-      ]
-    ]
-  ]
-
 config :core_web,
   generators: [context_app: :core]
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -54,3 +54,32 @@ if config_env() == :prod do
   # Then you can assemble a release by calling `mix release`.
   # See `mix help release` for more information.
 end
+
+case System.get_env("DEPLOY_ENV") do
+  "kubernetes" ->
+    config :libcluster,
+      topologies: [
+        funless_core: [
+          # The selected clustering strategy. Required.
+          strategy: Cluster.Strategy.Kubernetes,
+          config: [
+            kubernetes_ip_lookup_mode: :pods,
+            kubernetes_node_basename: "worker",
+            kubernetes_selector: "app=fl-worker",
+            kubernetes_namespace: "fl"
+          ]
+        ]
+      ]
+
+  _ ->
+    config :libcluster,
+      topologies: [
+        funless_core: [
+          # The selected clustering strategy. Required.
+          strategy: Cluster.Strategy.Gossip,
+          config: [
+            port: String.to_integer(System.get_env("FL_LIBCLUSTER_PORT") || "45892")
+          ]
+        ]
+      ]
+end


### PR DESCRIPTION
This PR adds the necessary changes for the deployment of fl-core on kind (see https://github.com/funlessdev/fl-deploy/pull/4).

Specifically:
- libcluster's strategy is now a runtime property, and can be either Gossip or Kubernetes
- the node name can be changed in the dockerized fl-core, using the `NODE_IP` environment variable