### PR TITLE
List functions

### DIFF
--- a/apps/core/lib/core/adapters/function_store/mnesia.ex
+++ b/apps/core/lib/core/adapters/function_store/mnesia.ex
@@ -92,4 +92,15 @@ defmodule Core.Adapters.FunctionStore.Mnesia do
       {_, :ok} -> {:ok, f_name}
     end
   end
+
+  @impl true
+  @spec list_functions(String.t()) :: {:ok, [String.t()]} | {:error, {:aborted, any}}
+  def list_functions(namespace) do
+    functions =
+      :mnesia.dirty_all_keys(FunctionStruct)
+      |> Enum.filter(&match?({_, ^namespace}, &1))
+      |> Enum.map(fn {n, _ns} -> n end)
+
+    {:ok, functions}
+  end
 end

--- a/apps/core/lib/core/adapters/function_store/test.ex
+++ b/apps/core/lib/core/adapters/function_store/test.ex
@@ -48,4 +48,9 @@ defmodule Core.Adapters.FunctionStore.Test do
   def delete_function(function_name, _function_namespace) do
     {:ok, function_name}
   end
+
+  @impl true
+  def list_functions(_namespace) do
+    {:ok, []}
+  end
 end

--- a/apps/core/lib/core/domain/api/function_repo.ex
+++ b/apps/core/lib/core/domain/api/function_repo.ex
@@ -102,7 +102,7 @@ defmodule Core.Domain.Api.FunctionRepo do
     result
   end
 
-  @spec list(map) :: {:ok, [String.t()]} | {:error, {:aborted, any}}
+  @spec list(map) :: {:ok, [String.t()]} | {:error, {:bad_list, any}} | {:error, :bad_params}
   def list(%{"namespace" => namespace}) do
     namespace
     |> FunctionStore.list_functions()
@@ -113,11 +113,13 @@ defmodule Core.Domain.Api.FunctionRepo do
     {:error, :bad_params}
   end
 
-  defp parse_list_result({:ok, l}) do
+  @spec parse_list_result({:ok, [String.t()]} | {:error, {:aborted, any}}) ::
+          {:ok, [String.t()]} | {:error, {:bad_list, any}}
+  def parse_list_result({:ok, l}) do
     {:ok, l}
   end
 
-  defp parse_list_result({:error, {:aborted, reason}}) do
+  def parse_list_result({:error, {:aborted, reason}}) do
     {:error, {:bad_list, reason}}
   end
 end

--- a/apps/core/lib/core/domain/api/function_repo.ex
+++ b/apps/core/lib/core/domain/api/function_repo.ex
@@ -102,8 +102,18 @@ defmodule Core.Domain.Api.FunctionRepo do
     result
   end
 
+  @spec list(map) :: {:ok, [String.t()]} | {:error, {:aborted, any}}
   def list(%{"namespace" => namespace}) do
     namespace
     |> FunctionStore.list_functions()
+    |> parse_list_result
+  end
+
+  defp parse_list_result({:ok, l}) do
+    {:ok, l}
+  end
+
+  defp parse_list_result({:error, {:aborted, reason}}) do
+    {:error, {:bad_list, reason}}
   end
 end

--- a/apps/core/lib/core/domain/api/function_repo.ex
+++ b/apps/core/lib/core/domain/api/function_repo.ex
@@ -109,6 +109,10 @@ defmodule Core.Domain.Api.FunctionRepo do
     |> parse_list_result
   end
 
+  def list(_) do
+    {:error, :bad_params}
+  end
+
   defp parse_list_result({:ok, l}) do
     {:ok, l}
   end

--- a/apps/core/lib/core/domain/api/function_repo.ex
+++ b/apps/core/lib/core/domain/api/function_repo.ex
@@ -101,4 +101,9 @@ defmodule Core.Domain.Api.FunctionRepo do
     Logger.info("API: delete returned #{inspect(result)} for function #{f_name}")
     result
   end
+
+  def list(%{"namespace" => namespace}) do
+    namespace
+    |> FunctionStore.list_functions()
+  end
 end

--- a/apps/core/lib/core/domain/ports/function_store.ex
+++ b/apps/core/lib/core/domain/ports/function_store.ex
@@ -28,6 +28,8 @@ defmodule Core.Domain.Ports.FunctionStore do
   @callback insert_function(FunctionStruct.t()) :: {:ok, String.t()} | {:error, {:aborted, any}}
   @callback delete_function(String.t(), String.t()) ::
               {:ok, String.t()} | {:error, {:aborted, any}}
+  @callback list_functions(String.t()) ::
+              {:ok, [String.t()]} | {:error, {:aborted, any}}
 
   @doc """
   Creates the Function database.
@@ -94,4 +96,18 @@ defmodule Core.Domain.Ports.FunctionStore do
   """
   @spec delete_function(String.t(), String.t()) :: {:ok, String.t()} | {:error, {:aborted, any}}
   defdelegate delete_function(function_name, function_namespace), to: @adapter
+
+  @doc """
+  Lists all functions in the given namespace.
+  Returns the list of functions or an {:error, err} tuple.
+
+  ## Parameters
+    - namespace: Namespace of the functions to be returned
+
+  ## Returns
+    - {:ok, functions}: if the functions were successfully retrieved from the database. The list can be empty.
+    - {:error, {:aborted, reason}}: if the functions could not be retrieved.
+  """
+  @spec list_functions(String.t()) :: {:ok, [String.t()]} | {:error, {:aborted, any}}
+  defdelegate list_functions(namespace), to: @adapter
 end

--- a/apps/core/test/unit/api_test/function_test.exs
+++ b/apps/core/test/unit/api_test/function_test.exs
@@ -88,7 +88,7 @@ defmodule ApiTest.FunctionTest do
       assert Api.FunctionRepo.delete(%{"namespace" => "ns"}) == {:error, :bad_params}
     end
 
-    test "delte shoulr return {:error, {:bad_delete, reason}} when the underlying store returns an error" do
+    test "delete should return {:error, {:bad_delete, reason}} when the underlying store returns an error" do
       Core.FunctionStore.Mock
       |> Mox.expect(:delete_function, 1, fn "hello", "ns" ->
         {:error, {:aborted, "for some reason"}}
@@ -103,6 +103,32 @@ defmodule ApiTest.FunctionTest do
 
       assert Api.FunctionRepo.delete(%{"name" => "not here", "namespace" => "ns"}) ==
                {:error, {:bad_delete, :not_found}}
+    end
+
+    test "list should return {:ok, functions} when no error occurs" do
+      assert Api.FunctionRepo.list(%{"namespace" => "ns"}) ==
+               {:ok, []}
+
+      Core.FunctionStore.Mock
+      |> Mox.expect(:list_functions, 1, fn "ns" -> {:ok, ["f1", "f2"]} end)
+
+      assert Api.FunctionRepo.list(%{"namespace" => "ns"}) ==
+               {:ok, ["f1", "f2"]}
+    end
+
+    test "list should return {:error, {:bad_list, reason}} when the underlying store returns an error" do
+      Core.FunctionStore.Mock
+      |> Mox.expect(:list_functions, 1, fn "ns" ->
+        {:error, {:aborted, "for some reason"}}
+      end)
+
+      assert Api.FunctionRepo.list(%{"namespace" => "ns"}) ==
+               {:error, {:bad_list, "for some reason"}}
+    end
+
+    test "list should return {:error, :bad_params} when the namespace is missing" do
+      assert Api.FunctionRepo.list(%{}) ==
+               {:error, :bad_params}
     end
   end
 end

--- a/apps/core_web/lib/core_web/controllers/fn_controller.ex
+++ b/apps/core_web/lib/core_web/controllers/fn_controller.ex
@@ -47,6 +47,18 @@ defmodule CoreWeb.FnController do
       |> json(%{result: function_name})
     end
   end
+
+  def list(conn, %{"namespace" => _namespace} = params) do
+    with {:ok, functions} <- FunctionRepo.list(params) do
+      conn
+      |> put_status(:ok)
+      |> json(%{result: functions})
+    end
+  end
+
+  def list(_conn, _params) do
+    {:error, {:bad_list, :no_namespace}}
+  end
 end
 
 defmodule CoreWeb.FnFallbackController do
@@ -111,6 +123,14 @@ defmodule CoreWeb.FnFallbackController do
 
     conn
     |> put_status(:service_unavailable)
+    |> json(res)
+  end
+
+  def call(conn, {:error, {:bad_list, :no_namespace}}) do
+    res = %{errors: %{detail: "Failed to list functions: no namespace provided"}}
+
+    conn
+    |> put_status(:bad_request)
     |> json(res)
   end
 end

--- a/apps/core_web/lib/core_web/controllers/fn_controller.ex
+++ b/apps/core_web/lib/core_web/controllers/fn_controller.ex
@@ -55,10 +55,6 @@ defmodule CoreWeb.FnController do
       |> json(%{result: functions})
     end
   end
-
-  def list(_conn, _params) do
-    {:error, {:bad_list, :no_namespace}}
-  end
 end
 
 defmodule CoreWeb.FnFallbackController do
@@ -126,11 +122,11 @@ defmodule CoreWeb.FnFallbackController do
     |> json(res)
   end
 
-  def call(conn, {:error, {:bad_list, :no_namespace}}) do
-    res = %{errors: %{detail: "Failed to list functions: no namespace provided"}}
+  def call(conn, {:error, {:bad_list, reason}}) do
+    res = %{errors: %{detail: "Failed to list functions: #{reason}"}}
 
     conn
-    |> put_status(:bad_request)
+    |> put_status(:service_unavailable)
     |> json(res)
   end
 end

--- a/apps/core_web/lib/core_web/router.ex
+++ b/apps/core_web/lib/core_web/router.ex
@@ -25,8 +25,8 @@ defmodule CoreWeb.Router do
     scope "/fn" do
       post("/create", FnController, :create)
       delete("/delete", FnController, :delete)
-
       post("/invoke", FnController, :invoke)
+      get("/list/:namespace", FnController, :list)
     end
   end
 

--- a/core-api.yaml
+++ b/core-api.yaml
@@ -83,6 +83,20 @@ components:
         error:
           type: string
           description: The error message
+    function_list_success:
+      type: object
+      properties:
+        result:
+          type: array
+          items:
+            type: integer
+          description: The names of the functions in the namespace
+    function_list_error:
+      type: object
+      properties:
+        error:
+          type: string
+          description: The error message
 
 paths:
   /v1/fn/invoke:
@@ -220,7 +234,40 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/function_deletion_error"
-
+  /v1/fn/list/{fnNamespace}:
+    get:
+      summary: List functions
+      parameters:
+      - in: path
+        name: fnNamespace
+        schema:
+          type: integer
+        required: true
+        description: Namespace of the listed functions
+      description: >-
+        List all functions in the given namespace
+      responses:
+        "200":
+          description: The required functions have been returned successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/function_list_success"
+              examples:
+                Listing a namespace with the "hellojs" function:
+                  value: '{"result": ["hellojs"]}'
+        "404":
+          description: The given namespace was not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/function_list_error"
+        "503":
+          description: The request failed because the database transaction was aborted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/function_list_error"
 servers:
   - url: http://localhost:4000
     variables: {}

--- a/core-api.yaml
+++ b/core-api.yaml
@@ -256,12 +256,6 @@ paths:
               examples:
                 Listing a namespace with the "hellojs" function:
                   value: '{"result": ["hellojs"]}'
-        "404":
-          description: The given namespace was not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/function_list_error"
         "503":
           description: The request failed because the database transaction was aborted
           content:


### PR DESCRIPTION
This PR adds the `/v1/fn/list/:namespace` endpoint to list all functions in a namespace.
The route and schema are subject to change in the future.

This closes #67.