### PR TITLE
Fixes

### DIFF
--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Core CI
+name: Core CI - Elixir Dialyzer
 
 on:
   push:

--- a/.github/workflows/generate-sdk.yml
+++ b/.github/workflows/generate-sdk.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Core CI
+name: Core CI - Generate API SDK
 
 on:
   push:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Core CI
+name: Core CI - Check License Headers
 
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Core CI
+name: Core CI - Elixir Linter and Formatter
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Core CI
+name: Core CI - Elixir Tests
 
 on:
   push:

--- a/apps/core/lib/core/domain/api/function_repo.ex
+++ b/apps/core/lib/core/domain/api/function_repo.ex
@@ -18,6 +18,7 @@ defmodule Core.Domain.Api.FunctionRepo do
   """
 
   require Logger
+  alias Core.Domain.Api.Utils
   alias Core.Domain.FunctionStruct
   alias Core.Domain.Ports.FunctionStore
 
@@ -35,9 +36,11 @@ defmodule Core.Domain.Api.FunctionRepo do
   @spec new(FunctionStruct.t()) ::
           {:ok, String.t()} | {:error, :bad_params} | {:error, {:bad_insert, any}}
   def new(%{"name" => name, "code" => code} = raw_params) do
+    namespace = Map.get(raw_params, "namespace") |> Utils.validate_namespace()
+
     function = %FunctionStruct{
       name: name,
-      namespace: raw_params["namespace"] || "_",
+      namespace: namespace,
       code: code
     }
 
@@ -63,7 +66,9 @@ defmodule Core.Domain.Api.FunctionRepo do
   """
   @spec delete(FunctionStruct.t()) ::
           {:ok, String.t()} | {:error, :bad_params} | {:error, {:bad_delete, any}}
-  def delete(%{"name" => name, "namespace" => namespace}) do
+  def delete(%{"name" => name} = raw_params) do
+    namespace = Map.get(raw_params, "namespace") |> Utils.validate_namespace()
+
     Logger.info("API: delete request for function #{name} in namespace #{namespace}")
 
     case FunctionStore.exists?(name, namespace) do

--- a/apps/core/lib/core/domain/api/invoker.ex
+++ b/apps/core/lib/core/domain/api/invoker.ex
@@ -17,6 +17,7 @@ defmodule Core.Domain.Api.Invoker do
   Provides functions to request function invocaiton.
   """
   require Logger
+  alias Core.Domain.Api.Utils
   alias Core.Domain.InvokeParams
   alias Core.Domain.InvokeResult
   alias Core.Domain.Nodes
@@ -45,9 +46,11 @@ defmodule Core.Domain.Api.Invoker do
   @spec invoke(InvokeParams.t()) ::
           {:ok, InvokeResult.t()} | {:error, :bad_params} | invoke_errors()
   def invoke(%{"function" => f} = raw_params) do
+    namespace = Map.get(raw_params, "namespace") |> Utils.validate_namespace()
+
     ivk_params = %InvokeParams{
       function: f,
-      namespace: Map.get(raw_params, "namespace", "_"),
+      namespace: namespace,
       args: Map.get(raw_params, "args", %{})
     }
 

--- a/apps/core/lib/core/domain/api/utils.ex
+++ b/apps/core/lib/core/domain/api/utils.ex
@@ -1,0 +1,38 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Domain.Api.Utils do
+  @moduledoc false
+
+  @doc """
+  Checks the given namespace string and returns the validated version of it.
+
+  ## Parameters
+  - ns: the namespace string to validate
+
+  ## Returns
+  - "_": if the string is nil, empty or blank (all whitespace), the default "_"
+  - String.trim(ns): otherwise, the trimmed version of the string is returned
+  """
+  @spec validate_namespace(String.t()) :: String.t()
+  def validate_namespace(ns) do
+    namespace = ns |> to_string |> String.trim()
+
+    if namespace == "" do
+      "_"
+    else
+      namespace
+    end
+  end
+end

--- a/apps/core/test/unit/api_test/util_test.exs
+++ b/apps/core/test/unit/api_test/util_test.exs
@@ -1,0 +1,58 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule ApiTest.UtilTest do
+  alias Core.Domain.Api.Utils
+  use ExUnit.Case
+  use Plug.Test
+
+  describe "API.Utils" do
+    test "validate_namespace should return _ if the given namespace is nil" do
+      expected = "_"
+      assert Utils.validate_namespace(nil) == expected
+    end
+
+    test "validate_namespace should return _ if the given namespace is empty" do
+      expected = "_"
+      assert Utils.validate_namespace("") == expected
+    end
+
+    test "validate_namespace should return _ if the given namespace is only whitespace" do
+      expected = "_"
+      assert Utils.validate_namespace("    ") == expected
+      assert Utils.validate_namespace("\n\n\n\n") == expected
+      assert Utils.validate_namespace(" \t\n \n\t ") == expected
+    end
+
+    test "validate_namespace should return the trimmed input if it is not empty, blank nor nil" do
+      expected = "ns"
+
+      input = "\n\nns\n\n"
+      assert Utils.validate_namespace(input) == expected
+
+      input = "\n\nns  "
+      assert Utils.validate_namespace(input) == expected
+
+      input = "\tns\r\n"
+      assert Utils.validate_namespace(input) == expected
+
+      input = "ns"
+      assert Utils.validate_namespace(input) == expected
+
+      input = "n s"
+      expected = "n s"
+      assert Utils.validate_namespace(input) == expected
+    end
+  end
+end


### PR DESCRIPTION
This PR adds two small fixes to fl-core:

- Github Actions now have clearer names
- The core now translates an empty namespace name to the default `"_"` string

This closes #78, #100.