### PR TITLE
Set correct types for /fn/list

### DIFF
--- a/core-api.yaml
+++ b/core-api.yaml
@@ -89,7 +89,7 @@ components:
         result:
           type: array
           items:
-            type: integer
+            type: string
           description: The names of the functions in the namespace
     function_list_error:
       type: object

--- a/core-api.yaml
+++ b/core-api.yaml
@@ -241,7 +241,7 @@ paths:
       - in: path
         name: fnNamespace
         schema:
-          type: integer
+          type: string
         required: true
         description: Namespace of the listed functions
       description: >-


### PR DESCRIPTION
This PR corrects a previous error in `core-api.yaml`, changing the type from `integer` to `string` for the namespace and results in `/fn/list`