### PR TITLE
handle function exec_error

### DIFF
--- a/apps/core/lib/core/adapters/commands/worker.ex
+++ b/apps/core/lib/core/adapters/commands/worker.ex
@@ -27,10 +27,8 @@ defmodule Core.Adapters.Commands.Worker do
   # {:ok, result}
   # {:error, :code_not_found} in this case re-do the invocation passing the code
   # {:error, atom()} mainly from the worker nifs
-  # {:error, %{"error" => msg}} a map with the reason
+  # {:error, {:exec_error, msg}} an error occurred during the execution of the function
 
-  # Handle the second type of error by logging and transforming it in :worker_error for the api
-  # Handle the third type of error by logging the message and transforming it in :worker_error for the api
   @impl true
   def send_invoke(worker, name, ns, args) do
     worker_addr = {:worker, worker}

--- a/apps/core/lib/core/domain/ports/commands.ex
+++ b/apps/core/lib/core/domain/ports/commands.ex
@@ -23,9 +23,9 @@ defmodule Core.Domain.Ports.Commands do
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
   @callback send_invoke(atom(), String.t(), String.t(), map()) ::
-              {:ok, InvokeResult.t()} | {:error, :code_not_found} | {:error, :worker_error}
+              {:ok, InvokeResult.t()} | {:error, :code_not_found} | {:error, any()}
   @callback send_invoke_with_code(atom(), FunctionStruct.t(), map()) ::
-              {:ok, InvokeResult.t()} | {:error, :worker_error}
+              {:ok, InvokeResult.t()} | {:error, any()}
 
   @doc """
   Sends an invoke command to a worker passing only the name and namespace of the function, and args.
@@ -33,7 +33,7 @@ defmodule Core.Domain.Ports.Commands do
   (optionally empty) function arguments.
   """
   @spec send_invoke(atom(), String.t(), String.t(), map()) ::
-          {:ok, InvokeResult.t()} | {:error, :code_not_found} | {:error, :worker_error}
+          {:ok, InvokeResult.t()} | {:error, :code_not_found} | {:error, String.t()}
   defdelegate send_invoke(worker, f_name, ns, args), to: @adapter
 
   @doc """
@@ -43,6 +43,6 @@ defmodule Core.Domain.Ports.Commands do
   (optionally empty) function arguments.
   """
   @spec send_invoke_with_code(atom(), FunctionStruct.t(), map()) ::
-          {:ok, InvokeResult.t()} | {:error, :worker_error}
+          {:ok, InvokeResult.t()} | {:error, String.t()}
   defdelegate send_invoke_with_code(worker, function, args), to: @adapter
 end

--- a/apps/core/test/unit/api_test/invoke_test.exs
+++ b/apps/core/test/unit/api_test/invoke_test.exs
@@ -47,9 +47,9 @@ defmodule ApiTest.InvokeTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, :worker_error} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, {:exec_error, "some error"}} end)
 
-      assert Invoker.invoke(%{"function" => "f"}) == {:error, :worker_error}
+      assert Invoker.invoke(%{"function" => "f"}) == {:error, {:exec_error, "some error"}}
     end
 
     test "invoke should return {:error, :no_workers} when no workers are found" do

--- a/apps/core_web/lib/core_web/controllers/fn_controller.ex
+++ b/apps/core_web/lib/core_web/controllers/fn_controller.ex
@@ -90,8 +90,8 @@ defmodule CoreWeb.FnFallbackController do
     |> json(res)
   end
 
-  def call(conn, {:error, :worker_error}) do
-    res = %{errors: %{detail: "Failed to invoke function: worker error"}}
+  def call(conn, {:error, {:exec_error, msg}}) do
+    res = %{errors: %{detail: "Failed to invoke function: #{msg}"}}
 
     conn
     |> put_status(:internal_server_error)

--- a/apps/core_web/test/core_web/controllers/fn_controller_test.exs
+++ b/apps/core_web/test/core_web/controllers/fn_controller_test.exs
@@ -69,10 +69,10 @@ defmodule CoreWeb.FnControllerTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, :worker_error} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, {:exec_error, "some error"}} end)
 
       conn = post(conn, "/v1/fn/invoke", %{function: "test", code: ""})
-      expected = %{"errors" => %{"detail" => "Failed to invoke function: worker error"}}
+      expected = %{"errors" => %{"detail" => "Failed to invoke function: some error"}}
       assert json_response(conn, 500) == expected
     end
 


### PR DESCRIPTION
This PR closes #69 

In case of execution error, the worker forwards :exec_error, which was not handled in the frontend.